### PR TITLE
Add prop approvalPrompt to allow for forcing user to grant permission…

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ If you use the hostedDomain param, make sure to validate the id_token (a JSON we
 |    style     |  object  |                   -                  |
 |   loginHint  |  string  |                   -                  |
 | redirectUri  |  string  |              postmessage             |
+|approvalPrompt|  string  |                   -                  |
+
 
 Google Scopes List: https://developers.google.com/identity/protocols/googlescopes
 
@@ -80,6 +82,9 @@ You can also access the returned values via the following properties on the retu
 | property name |  value   |             definition               |
 |:-------------:|:--------:|:------------------------------------:|
 |    code       |  object  |           offline token              |
+
+If `approvalPrompt` is set to `"force"`, refresh token will always be returned while exchanging auth code for tokens. 
+Otherwise, refresh token will only be returned for the first time user gives permission to the app.
 
 You can now also pass child components such as icons into the button component.
 ```js

--- a/src/google.js
+++ b/src/google.js
@@ -15,6 +15,7 @@ class GoogleLogin extends Component {
     hostedDomain: PropTypes.string,
     children: React.PropTypes.node,
     style: React.PropTypes.object,
+    approvalPrompt: PropTypes.string,
   };
 
   static defaultProps = {
@@ -64,10 +65,11 @@ class GoogleLogin extends Component {
 
   onBtnClick() {
     const auth2 = window.gapi.auth2.getAuthInstance();
-    const { offline, redirectUri, onSuccess, onFailure } = this.props;
+    const { offline, redirectUri, onSuccess, onFailure, approvalPrompt } = this.props;
     if (offline) {
       const options = {
         redirect_uri: redirectUri,
+        approval_prompt: approvalPrompt,
       };
       auth2.grantOfflineAccess(options)
         .then(res => {


### PR DESCRIPTION
The need for this enhancement arose in my project. I have already edited the library and am using it to fit my need, thought I should contribute it here as well.  :)

Here is the use case:

In case of offline, [auth code can be exchanged for refresh token only once](http://stackoverflow.com/a/10857806/1167918). This can become problematic if something goes wrong on the server (user has to go back and revoke app permissions from their google account to get refresh token again, totally not feasible!) so there can be a use case where the programmer wants to show approval prompt to user every time to ensure availability of refresh token. 

Setting approvalPrompt to force fixes this problem. 