### PR TITLE
Use version as used in DefinitelyTyped packages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     ]
   },
   "dependencies": {
-    "@types/react": "^0.14.44"
+    "@types/react": "*"
   }
 }


### PR DESCRIPTION
I take a look how dependencies defined in `@types`, and looks like best practice here - define dependency with wildcard, because if in `node_modules` we got two different version of one definition (for example react) typescript become mad.

package.json of `@types/react-redux`
```
{
    "name": "@types/react-redux",
    "dependencies": {
        "@types/react": "*",
        "@types/redux": "*"
    }
}
```
