### PR TITLE
Usage of different scopes by multiple GoogleLogin component issue fix

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -17,19 +17,38 @@ const loading = () => {
 };
 
 ReactDOM.render(
-  <GoogleLogin
-    clientId='658977310896-knrl3gka66fldh83dao2rhgbblmd4un9.apps.googleusercontent.com'
-    onSuccess={success}
-    onFailure={error}
-    onRequest={loading}
-    offline={false}
-    approvalPrompt="force"
-    // disabled
-    // prompt="consent"
-    // className='button'
-    // style={{ color: 'red' }}
-  >
-    <span> Login with Google</span>
-  </GoogleLogin>,
+  <div>
+    <GoogleLogin
+        clientId='658977310896-knrl3gka66fldh83dao2rhgbblmd4un9.apps.googleusercontent.com'
+        scope='https://www.googleapis.com/auth/analytics'
+        onSuccess={success}
+        onFailure={error}
+        onRequest={loading}
+        offline={false}
+        approvalPrompt="force"
+        // disabled
+        // prompt="consent"
+        // className='button'
+        // style={{ color: 'red' }}
+    >
+      <span>Analytics</span>
+    </GoogleLogin>
+
+    <GoogleLogin
+        clientId='658977310896-knrl3gka66fldh83dao2rhgbblmd4un9.apps.googleusercontent.com'
+        scope='https://www.googleapis.com/auth/adwords'
+        onSuccess={success}
+        onFailure={error}
+        onRequest={loading}
+        offline={false}
+        approvalPrompt="force"
+        // disabled
+        // prompt="consent"
+        // className='button'
+        // style={{ color: 'red' }}
+    >
+      <span>Adwords</span>
+    </GoogleLogin>
+  </div>,
   document.getElementById('google-login')
 );

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ class GoogleLogin extends Component {
     };
   }
   componentDidMount() {
-    const { clientId, scope, cookiePolicy, loginHint, hostedDomain, autoLoad, fetchBasicProfile } = this.props;
+    const { clientId, cookiePolicy, loginHint, hostedDomain, autoLoad, fetchBasicProfile } = this.props;
     ((d, s, id, cb) => {
       const element = d.getElementsByTagName(s)[0];
       const fjs = element;
@@ -25,8 +25,7 @@ class GoogleLogin extends Component {
         cookiepolicy: cookiePolicy,
         login_hint: loginHint,
         hosted_domain: hostedDomain,
-        fetch_basic_profile: fetchBasicProfile,
-        scope,
+        fetch_basic_profile: fetchBasicProfile
       };
       window.gapi.load('auth2', () => {
         this.setState({
@@ -45,11 +44,12 @@ class GoogleLogin extends Component {
   signIn() {
     if (!this.state.disabled) {
       const auth2 = window.gapi.auth2.getAuthInstance();
-      const { offline, redirectUri, onSuccess, onRequest, fetchBasicProfile, onFailure, prompt } = this.props;
+      const { offline, redirectUri, onSuccess, onRequest, fetchBasicProfile, onFailure, prompt, scope } = this.props;
       const options = {
         redirect_uri: redirectUri,
         fetch_basic_profile: fetchBasicProfile,
         prompt,
+        scope
       };
       onRequest();
       if (offline) {


### PR DESCRIPTION
Hi,

I encountered the problem using multiple GoogleLogin component with different scopes, for example one for Analytics and one for Adwords.

In the existing master the will both refer to the same scope.

It seems to be fixed by replacing the scope as options from auth2.init to auth2.signIn

Let me know what you think.