### PR TITLE
Added support for discoveryDocs from props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ class GoogleLogin extends Component {
     };
   }
   componentDidMount() {
-    const { clientId, scope, cookiePolicy, loginHint, hostedDomain, autoLoad, fetchBasicProfile } = this.props;
+    const { clientId, scope, cookiePolicy, loginHint, hostedDomain, autoLoad, fetchBasicProfile, discoveryDocs } = this.props;
     ((d, s, id, cb) => {
       const element = d.getElementsByTagName(s)[0];
       const fjs = element;
@@ -27,6 +27,7 @@ class GoogleLogin extends Component {
         hosted_domain: hostedDomain,
         fetch_basic_profile: fetchBasicProfile,
         scope,
+        discoveryDocs,
       };
       window.gapi.load('auth2', () => {
         this.setState({
@@ -149,6 +150,7 @@ GoogleLogin.propTypes = {
   tag: PropTypes.string,
   autoLoad: React.PropTypes.bool,
   disabled: React.PropTypes.bool,
+  discoveryDocs: React.PropTypes.array,
 };
 
 GoogleLogin.defaultProps = {


### PR DESCRIPTION
I'm primarily using this param for accessing the REST API from my Google App Script, but there's a lot more it can be used for

Check out: [https://developers.google.com/discovery/v1/using](https://developers.google.com/discovery/v1/using
)

- React.PropTypes.array
- no default