### PR TITLE
add `approvalPrompt` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ If you use the hostedDomain param, make sure to validate the id_token (a JSON we
 | disabledStyle|  object  |                   -                  |                  |
 |   loginHint  |  string  |                   -                  |                  |
 |    prompt    |  string  |                   -                  |                  |
+| approvalPrompt |  string  |                   -                  |                  |
 |     tag      |  string  |                button                |  sets element tag (div, a, span, etc     |
 |   autoLoad   |  boolean |                 false                |                  |
 | fetchBasicProfile | boolean | true                            |                  |

--- a/src/index.js
+++ b/src/index.js
@@ -52,11 +52,12 @@ class GoogleLogin extends Component {
     }
     if (!this.state.disabled) {
       const auth2 = window.gapi.auth2.getAuthInstance();
-      const { offline, redirectUri, onSuccess, onRequest, fetchBasicProfile, onFailure, prompt, scope, responseType } = this.props;
+      const { offline, redirectUri, onSuccess, onRequest, fetchBasicProfile, onFailure, prompt, approvalPrompt, scope, responseType } = this.props;
       const options = {
         response_type: responseType,
         redirect_uri: redirectUri,
         fetch_basic_profile: fetchBasicProfile,
+        approval_prompt: approvalPrompt,
         prompt,
         scope,
       };
@@ -155,6 +156,7 @@ GoogleLogin.propTypes = {
   disabledStyle: React.PropTypes.object,
   fetchBasicProfile: PropTypes.bool,
   prompt: PropTypes.string,
+  approvalPrompt: PropTypes.string,
   tag: PropTypes.string,
   autoLoad: PropTypes.bool,
   disabled: PropTypes.bool,
@@ -169,6 +171,7 @@ GoogleLogin.defaultProps = {
   scope: 'profile email',
   responseType: 'permission',
   prompt: '',
+  approvalPrompt: '',
   cookiePolicy: 'single_host_origin',
   fetchBasicProfile: true,
   uxMode: 'popup',


### PR DESCRIPTION
Needed to get a `code` response to get a refresh
code later. Adding this prop as `approvalPrompt="force"`
in the component. Changes the response from Google as

```js
{
  code: '4/UrnXy1QQ_3GQQF3NC1...'
}
```

Then, whit this code I can call a `refresh_token` by performing a
`POST` action to `https://www.googleapis.com/oauth2/v4/token`
as described in the google link documentation (Step 5 in page).

http://stackoverflow.com/questions/34949727/google-javascript-sign-in-api-no-offline-access

https://developers.google.com/identity/protocols/OAuth2WebServer