### PR TITLE
Add `prompt` to `GoogleLoginProps` on index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -68,6 +68,7 @@ declare namespace ReactGoogleLogin {
     readonly cookiePolicy?: string,
     readonly loginHint?: string,
     readonly hostedDomain?: string,
+    readonly prompt?: string,
     readonly children?: ReactNode,
     readonly style?: CSSProperties,
     readonly tag?: string;


### PR DESCRIPTION
`prompt` is in the `PropTypes` but not the `.d.ts`, leading to typescript compiler errors.