### PR TITLE
Use responseType to determine if `.grantOfflineAccess()` should be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ If you use the hostedDomain param, make sure to validate the id_token (a JSON we
 |    clientId  |  string  |               REQUIRED               |                  |
 | hostedDomain |  string  |                   -                  |                  |
 |     scope    |  string  |             profile email            |                  |
-| responseType |  string  |              permission              | A list of space-delimited response type. The possible values are: id_token, to retrieve an ID Token permission (or token), to retrieve an Access Token code, to retrieve an Authorization Code             |
+| responseType |  string  |              permission              | A list of space-delimited response type. Defaults to 'permission'. The possible values are: 'id_token', to retrieve an ID Token, 'permission' (or 'token'), to retrieve an Access Token and 'code', to retrieve an Authorization Code
+             |
 |   onSuccess  | function |               REQUIRED               |                  |
 |   onFailure  | function |               REQUIRED               |                  |
 |   onRequest  | function |                   -                  |                  |

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ ReactDOM.render(
 ```
 ## onSuccess callback
 
-If offline is false callback will return the GoogleAuth object.
+If responseType is not 'code', callback will return the GoogleAuth object.
 
-If offline is true callback will return the offline token for use on your server.
+If responseType is 'code', callback will return the offline token for use on your server.
 
 If you use the hostedDomain param, make sure to validate the id_token (a JSON web token) returned by Google on your backend server:
  1. In the `responseGoogle(response) {...}` callback function, you should get back a standard JWT located at `response.hg.id_token`
@@ -47,12 +47,11 @@ If you use the hostedDomain param, make sure to validate the id_token (a JSON we
 |    clientId  |  string  |               REQUIRED               |                  |
 | hostedDomain |  string  |                   -                  |                  |
 |     scope    |  string  |             profile email            |                  |
-| responseType |  string  |              permission              | A list of space-delimited response type. Defaults to 'permission'. The possible values are: 'id_token', to retrieve an ID Token, 'permission' (or 'token'), to retrieve an Access Token and 'code', to retrieve an Authorization Code
+| responseType |  string  |              permission              | Can be either space-delimited 'id_token', to retrieve an ID Token + 'permission' (or 'token'), to retrieve an Access Token, or 'code', to retrieve an Authorization Code.
              |
 |   onSuccess  | function |               REQUIRED               |                  |
 |   onFailure  | function |               REQUIRED               |                  |
 |   onRequest  | function |                   -                  |                  |
-|    offline   |  boolean |                 false                |                  |
 |   buttonText |  string  |             Login with Google        |                  |
 |   className  |  string  |                   -                  |                  |
 |    style     |  object  |                   -                  |                  |
@@ -96,7 +95,6 @@ You can also pass child components such as icons into the button component.
     clientId={'658977310896-knrl3gka66fldh83dao2rhgbblmd4un9.apps.googleusercontent.com'}
     onSuccess={responseGoogle}
     onFailure={responseGoogle}
-    offline={false}
   >
     <FontAwesome
       name='google'

--- a/demo/index.js
+++ b/demo/index.js
@@ -42,8 +42,8 @@ ReactDOM.render(
         onSuccess={success}
         onFailure={error}
         onRequest={loading}
-        offline={true}
         approvalPrompt="force"
+        responseType="code"
         // uxMode="redirect"
         // redirectUri="http://google.com"
         // disabled

--- a/index.d.ts
+++ b/index.d.ts
@@ -61,7 +61,6 @@ declare namespace ReactGoogleLogin {
     readonly clientId: string,
     readonly onRequest?: () => void,
     readonly buttonText?: string,
-    readonly offline?: boolean,
     readonly scope?: string,
     readonly className?: string,
     readonly redirectUri?: string,

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ class GoogleLogin extends Component {
     }
     if (!this.state.disabled) {
       const auth2 = window.gapi.auth2.getAuthInstance();
-      const { offline, redirectUri, onSuccess, onRequest, fetchBasicProfile, onFailure, prompt, scope, responseType } = this.props;
+      const { redirectUri, onSuccess, onRequest, fetchBasicProfile, onFailure, prompt, scope, responseType } = this.props;
       const options = {
         response_type: responseType,
         redirect_uri: redirectUri,
@@ -66,7 +66,7 @@ class GoogleLogin extends Component {
         scope,
       };
       onRequest();
-      if (offline) {
+      if (responseType === 'code') {
         auth2.grantOfflineAccess(options)
           .then(
             res => onSuccess(res),
@@ -150,7 +150,6 @@ GoogleLogin.propTypes = {
   clientId: PropTypes.string.isRequired,
   onRequest: PropTypes.func,
   buttonText: PropTypes.string,
-  offline: PropTypes.bool,
   scope: PropTypes.string,
   className: PropTypes.string,
   redirectUri: PropTypes.string,
@@ -185,7 +184,6 @@ GoogleLogin.defaultProps = {
     opacity: 0.6,
   },
   onRequest: () => {},
-  offline: false,
 };
 
 export default GoogleLogin;


### PR DESCRIPTION
I barely know JS, so this change can eat your kitten blabla, but anyway: there is no need to have specific property for offline access, we can determine it from responseType, especially that google can't return both code & access_token/id_token.

Description of responseType in README is rather bad, but I can't come up with something better.  
First commit is from https://github.com/anthonyjgrove/react-google-login/pull/82: I don't really know if this PR will be merged, but I assume both commits can be squashed if it is.