### PR TITLE
Add responseType to GoogleLoginProps typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -68,6 +68,7 @@ declare namespace ReactGoogleLogin {
     readonly loginHint?: string,
     readonly hostedDomain?: string,
     readonly prompt?: string,
+    readonly responseType?: string,
     readonly children?: ReactNode,
     readonly style?: CSSProperties,
     readonly tag?: string,


### PR DESCRIPTION
In the process of transitioning to use responseType to infer if offline access is needed (https://github.com/anthonyjgrove/react-google-login/commit/14e7213cde9f681b1c2083ffa230cb25f7a5f499), I noticed that the type for the `responseType` param does not exist.

I would prefer to be more strict ie: `readonly responseType?: 'code',` but I'm not 100% sure if that is correct.