### PR TITLE
Types declaration - default export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,8 +75,8 @@ declare namespace ReactGoogleLogin {
     readonly disabled?: boolean;
   }
 
-  export default class GoogleLogin extends Component<GoogleLoginProps, {}> {
+  export class GoogleLogin extends Component<GoogleLoginProps, {}> {
   }
 }
 
-export = ReactGoogleLogin;
+export = ReactGoogleLogin.GoogleLogin;


### PR DESCRIPTION
Since it's written as an UMD module, we cannot use "export default" inside a namespace.