### PR TITLE
Fix for TS1319

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Ruslan Ibragimov <https://github.com/IRus>
 import {Component, ReactNode, CSSProperties} from 'react';
 
-declare namespace ReactGoogleLogin {
+export namespace ReactGoogleLogin {
 
   interface AuthResponse {
     readonly access_token: string;
@@ -68,15 +68,14 @@ declare namespace ReactGoogleLogin {
     readonly loginHint?: string,
     readonly hostedDomain?: string,
     readonly prompt?: string,
-    readonly responseType?: string,
     readonly children?: ReactNode,
     readonly style?: CSSProperties,
     readonly tag?: string,
     readonly disabled?: boolean;
   }
 
-  export default class GoogleLogin extends Component<GoogleLoginProps, {}> {
+  export class GoogleLogin extends Component<GoogleLoginProps, {}> {
   }
 }
 
-export = ReactGoogleLogin;
+export default ReactGoogleLogin.GoogleLogin;


### PR DESCRIPTION
Avoids breaking backwards compatibility with `import GoogleLogin from 'react-google-login'`