### PR TITLE
Typescript: Add responseType back after it was removed in #107

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -68,6 +68,7 @@ export namespace ReactGoogleLogin {
     readonly loginHint?: string,
     readonly hostedDomain?: string,
     readonly prompt?: string,
+    readonly responseType?: string,
     readonly children?: ReactNode,
     readonly style?: CSSProperties,
     readonly tag?: string,


### PR DESCRIPTION
see: https://github.com/anthonyjgrove/react-google-login/pull/107/files#diff-b52768974e6bc0faccb7d4b75b162c99L71