### PR TITLE
Prevent setState on unmounted component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ class GoogleLogin extends Component {
   constructor(props) {
     super(props)
     this.signIn = this.signIn.bind(this)
+    this.enableButton = this.enableButton.bind(this)
     this.state = {
       disabled: true
     }
@@ -33,9 +34,7 @@ class GoogleLogin extends Component {
         scope
       }
       window.gapi.load('auth2', () => {
-        this.setState({
-          disabled: false
-        })
+        this.enableButton()
         if (!window.gapi.auth2.getAuthInstance()) {
           window.gapi.auth2.init(params).then(
             res => {
@@ -50,6 +49,14 @@ class GoogleLogin extends Component {
           this.signIn()
         }
       })
+    })
+  }
+  componentWillUnmount() {
+    this.enableButton = () => {}
+  }
+  enableButton() {
+    this.setState({
+      disabled: false
     })
   }
   signIn(e) {
@@ -72,8 +79,8 @@ class GoogleLogin extends Component {
   }
   _handleSigninSuccess(res) {
     /*
-      offer renamed response keys to names that match use
-    */
+     offer renamed response keys to names that match use
+     */
     const basicProfile = res.getBasicProfile()
     const authResponse = res.getAuthResponse()
     res.googleId = basicProfile.getId()


### PR DESCRIPTION
Prevent setState from being called when Google library is loaded after
the component has already unmounted.

Fixes #86