### PR TITLE
Pass access_type: offline parameter when responseType === "code"

### DIFF
--- a/src/GoogleLogin.js
+++ b/src/GoogleLogin.js
@@ -10,7 +10,7 @@ class GoogleLogin extends Component {
     }
   }
   componentDidMount() {
-    const { clientId, cookiePolicy, loginHint, hostedDomain, autoLoad, isSignedIn, fetchBasicProfile, redirectUri, discoveryDocs, onFailure, uxMode, scope } = this.props
+    const { clientId, cookiePolicy, loginHint, hostedDomain, autoLoad, isSignedIn, fetchBasicProfile, redirectUri, discoveryDocs, onFailure, uxMode, scope, responseType } = this.props
       ; ((d, s, id, cb) => {
         const element = d.getElementsByTagName(s)[0]
         const fjs = element
@@ -32,6 +32,11 @@ class GoogleLogin extends Component {
           redirect_uri: redirectUri,
           scope
         }
+
+        if (responseType === 'code') {
+          params.access_type = 'offline';
+        }
+
         window.gapi.load('auth2', () => {
           this.setState({
             disabled: false


### PR DESCRIPTION
When I was using `responseType="code"`, my server still wasn't working correctly for `offline` mode. Google developer docs says:

```
Recommended. Indicates whether your application can refresh access tokens when the user is not present at the browser. Valid parameter values are online, which is the default value, and offline.

Set the value to offline if your application needs to refresh access tokens when the user is not present at the browser. This is the method of refreshing access tokens described later in this document. This value instructs the Google authorization server to return a refresh token and an access token the first time that your application exchanges an authorization code for tokens. 
```

This is available at https://developers.google.com/identity/protocols/OAuth2WebServer. (search for access_type until you see the parameter documentation)