### PR TITLE
Add reloadAuthResponse to GoogleLoginResponse type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,7 @@ interface BasicProfile {
 export interface GoogleLoginResponse {
   getBasicProfile(): BasicProfile;
   getAuthResponse(): AuthResponse;
+  reloadAuthResponse(): Promise<AuthResponse>;
   getGrantedScopes(): string;
   getHostedDomain(): string;
   getId(): string;


### PR DESCRIPTION
...cuz it's totally on there:

![image](https://user-images.githubusercontent.com/871117/54309442-5dec8e00-458d-11e9-812e-00ad8fe136a3.png)
