### PR TITLE
Should be response.Zi.id_token, not response.hg.id_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If responseType is not 'code', callback will return the GoogleAuth object.
 If responseType is 'code', callback will return the offline token for use on your server.
 
 If you use the hostedDomain param, make sure to validate the id_token (a JSON web token) returned by Google on your backend server:
- 1. In the `responseGoogle(response) {...}` callback function, you should get back a standard JWT located at `response.hg.id_token`
+ 1. In the `responseGoogle(response) {...}` callback function, you should get back a standard JWT located at `response.Zi.id_token`
  2. Send this token to your server (preferably as an `Authorization` header)
  3. Have your server decode the id_token by using a common JWT library such as [jwt-simple](https://github.com/hokaccha/node-jwt-simple) or by sending a GET request to `https://www.googleapis.com/oauth2/v3/tokeninfo?id_token=YOUR_TOKEN_HERE`
  4. The returned decoded token should have an `hd` key equal to the hosted domain you'd like to restrict to.


### PR DESCRIPTION
At least, that's what I got when I tried using this library myself.