### PR TITLE
Aligning render props type definition with implementation.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,7 +82,7 @@ export interface GoogleLoginProps {
   readonly isSignedIn?: boolean;
   readonly type?: string;
   readonly accessType?: string;
-  readonly render?: (props: { onClick: () => void }) => JSX.Element;
+  readonly render?: (props: { onClick: () => void, disabled: boolean }) => JSX.Element;
 }
 
 export class GoogleLogin extends Component<GoogleLoginProps, {}> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,7 +82,7 @@ export interface GoogleLoginProps {
   readonly isSignedIn?: boolean;
   readonly type?: string;
   readonly accessType?: string;
-  readonly render?: (props?: { onClick: () => void }) => JSX.Element;
+  readonly render?: (props: { onClick: () => void }) => JSX.Element;
 }
 
 export class GoogleLogin extends Component<GoogleLoginProps, {}> {
@@ -100,7 +100,7 @@ export interface GoogleLogoutProps {
   readonly disabled?: boolean;
   readonly disabledStyle?: CSSProperties;
   readonly tag?: string;
-  readonly render?: (props?: { onClick: () => void }) => JSX.Element;
+  readonly render?: (props: { onClick: () => void }) => JSX.Element;
 }
 
 export class GoogleLogout extends Component<GoogleLogoutProps, {}> {


### PR DESCRIPTION
Props are always provided for custom render functions.

Login: https://github.com/anthonyjgrove/react-google-login/blob/master/src/google-login.js#L128
Logout: https://github.com/anthonyjgrove/react-google-login/blob/master/src/google-logout.js#L88