### PR TITLE
re-send `scope` on signIn

### DIFF
--- a/src/google-login.js
+++ b/src/google-login.js
@@ -87,9 +87,10 @@ class GoogleLogin extends Component {
     }
     if (!this.state.disabled) {
       const auth2 = window.gapi.auth2.getAuthInstance()
-      const { onSuccess, onRequest, onFailure, prompt, responseType } = this.props
+      const { onSuccess, onRequest, onFailure, prompt, scope, responseType } = this.props
       const options = {
-        prompt
+        prompt,
+        scope
       }
       onRequest()
       if (responseType === 'code') {


### PR DESCRIPTION
Fixes a bug when `auth2` initialize with some scopes and later on changed to something else.