### PR TITLE
Add type "onFailure" to interface GoogleLogoutProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -93,6 +93,7 @@ export class GoogleLogin extends Component<GoogleLoginProps, {}> {
 export interface GoogleLogoutProps {
   readonly clientId: string,
   readonly onLogoutSuccess?: () => void;
+  readonly onFaliure?: () => void;
   readonly buttonText?: string;
   readonly className?: string;
   readonly children?: ReactNode;


### PR DESCRIPTION
Add the type "onFailure" to interface GoogleLogoutProps to enable "onFailure" with Typescript