### PR TITLE
Add missing props to GoogleLoginResponse interface in type-definition.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,19 @@ export interface GoogleLoginResponse {
   grantOfflineAccess(options: GrantOfflineAccessOptions): Promise<GoogleLoginResponseOffline>;
   signIn(options: SignInOptions): Promise<any>;
   grant(options: SignInOptions): Promise<any>;
+  // google-login.js sez: offer renamed response keys to names that match use
+  googleId: string;
+  tokenObj: AuthResponse;
+  tokenId: string;
+  accessToken: string;
+  profileObj: {
+    googleId: string;
+    imageUrl: string;
+    email: string;
+    name: string;
+    givenName: string;
+    familyName: string;
+  }
 }
 
 interface GrantOfflineAccessOptions {


### PR DESCRIPTION
This ought to fix #212  