### PR TITLE
Fix onFailure typo in GoogleLogoutProps interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -106,7 +106,7 @@ export class GoogleLogin extends Component<GoogleLoginProps, {}> {
 export interface GoogleLogoutProps {
   readonly clientId: string,
   readonly onLogoutSuccess?: () => void;
-  readonly onFaliure?: () => void;
+  readonly onFailure?: () => void;
   readonly buttonText?: string;
   readonly className?: string;
   readonly children?: ReactNode;


### PR DESCRIPTION
Tiny fix – looks like this typo showed up in 5.0.6

🙌  Thanks for the component!