### PR TITLE
Add icon prop to GoogleLoginProps in type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -86,6 +86,7 @@ export interface GoogleLoginProps {
   readonly responseType?: string,
   readonly children?: ReactNode,
   readonly style?: CSSProperties,
+  readonly icon?: boolean,
   readonly theme?: "light" | "dark",
   readonly tag?: string,
   readonly disabled?: boolean;


### PR DESCRIPTION
Regarding this [issue](https://github.com/anthonyjgrove/react-google-login/issues/244) icon is not available as property on `GoogleLogin` component
`icon` prop is added to GoogleLoginProps type definition.