### PR TITLE
fix(zi-object): Add manually zi object to support old users, and upda…

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ If responseType is not 'code', callback will return the GoogleAuth object.
 If responseType is 'code', callback will return the offline token for use on your server.
 
 If you use the hostedDomain param, make sure to validate the id_token (a JSON web token) returned by Google on your backend server:
- 1. In the `responseGoogle(response) {...}` callback function, you should get back a standard JWT located at `response.Zi.id_token`
+ 1. In the `responseGoogle(response) {...}` callback function, you should get back a standard JWT located at `response.id_token`
  2. Send this token to your server (preferably as an `Authorization` header)
  3. Have your server decode the id_token by using a common JWT library such as [jwt-simple](https://github.com/hokaccha/node-jwt-simple) or by sending a GET request to `https://www.googleapis.com/oauth2/v3/tokeninfo?id_token=YOUR_TOKEN_HERE`
  4. The returned decoded token should have an `hd` key equal to the hosted domain you'd like to restrict to.

--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -41,6 +41,10 @@ const useGoogleLogin = ({
       givenName: basicProfile.getGivenName(),
       familyName: basicProfile.getFamilyName()
     }
+    /*
+      Add Zi object manually to support people who relies on older docs
+    */
+    res.Zi = res.authResponse
     onSuccess(res)
   }
 


### PR DESCRIPTION
For some reason, the Zi object is not anymore in the response, and I can't find any change both in this package or the google api package that can generate this breaking change, so I decided to update docs to avoid its use.

Also, the useGoogleLogin hook was update in order to manually create the Zi object for those who relies on its correct functionality.

No breaking changes and test passing.

Fixes #298 