### PR TITLE
Bugfix async race condition

### DIFF
--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -55,9 +55,15 @@ const useGoogleLogin = ({
       }
       onRequest()
       if (responseType === 'code') {
-        auth2.grantOfflineAccess(options).then(res => onSuccess(res), err => onFailure(err))
+        auth2.grantOfflineAccess(options).then(
+          res => onSuccess(res),
+          err => onFailure(err)
+        )
       } else {
-        auth2.signIn(options).then(res => handleSigninSuccess(res), err => onFailure(err))
+        auth2.signIn(options).then(
+          res => handleSigninSuccess(res),
+          err => onFailure(err)
+        )
       }
     }
   }

--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -88,16 +88,18 @@ const useGoogleLogin = ({
       }
 
       window.gapi.load('auth2', () => {
-        setLoaded(true)
         if (!window.gapi.auth2.getAuthInstance()) {
           window.gapi.auth2.init(params).then(
             res => {
+              setLoaded(true)
               if (isSignedIn && res.isSignedIn.get()) {
                 handleSigninSuccess(res.currentUser.get())
               }
             },
             err => onFailure(err)
           )
+        } else {
+          setLoaded(true)
         }
       })
     })

--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -55,15 +55,9 @@ const useGoogleLogin = ({
       }
       onRequest()
       if (responseType === 'code') {
-        auth2.grantOfflineAccess(options).then(
-          res => onSuccess(res),
-          err => onFailure(err)
-        )
+        auth2.grantOfflineAccess(options).then(res => onSuccess(res), err => onFailure(err))
       } else {
-        auth2.signIn(options).then(
-          res => handleSigninSuccess(res),
-          err => onFailure(err)
-        )
+        auth2.signIn(options).then(res => handleSigninSuccess(res), err => onFailure(err))
       }
     }
   }

--- a/src/use-google-logout.js
+++ b/src/use-google-logout.js
@@ -43,10 +43,7 @@ const useGoogleLogout = ({
       }
       window.gapi.load('auth2', () => {
         if (!window.gapi.auth2.getAuthInstance()) {
-          window.gapi.auth2.init(params).then(
-            () => setLoaded(true),
-            err => onFailure(err)
-          )
+          window.gapi.auth2.init(params).then(() => setLoaded(true), err => onFailure(err))
         } else {
           setLoaded(true)
         }

--- a/src/use-google-logout.js
+++ b/src/use-google-logout.js
@@ -42,9 +42,13 @@ const useGoogleLogout = ({
         access_type: accessType
       }
       window.gapi.load('auth2', () => {
-        setLoaded(true)
         if (!window.gapi.auth2.getAuthInstance()) {
-          window.gapi.auth2.init(params).then(() => {}, err => onFailure(err))
+          window.gapi.auth2.init(params).then(
+            () => setLoaded(true),
+            err => onFailure(err)
+          )
+        } else {
+          setLoaded(true)
         }
       })
     })


### PR DESCRIPTION
Current functionality has a race condition if the signOut call is used before the auth2.init() is not finished 

example: 
```javascript 
const { signOut, loaded } = useGoogleLogout({
    clientId,
    jsSrc,
    onLogoutSuccess: () => {
      "we logged out!";
    }
  });
  useEffect(() => {
    if (loaded) {
      signOut();
    }
  }, [loaded, signOut]);
```

would fail and the onLogoutSuccess would never be called