### PR TITLE
Polish the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Use GoogleLogout button to logout the user from google.
 |    style     |  object  |                   -                  |                  |
 | disabledStyle|  object  |                   -                  |                  |
 |   loginHint  |  string  |                   -                  |                  |
-|    prompt    |  string  |                   -                  |                  |
+|    prompt    |  string  |                   -                  | Can be 'consent' to force google return refresh token.                |
 |     tag      |  string  |                button                |  sets element tag (div, a, span, etc     |
 |     type      |  string  |               button                |sets button type (submit || button)     |
 |   autoLoad   |  boolean |                 false                |                  |


### PR DESCRIPTION
## Problem

Google will not return refresh token when a user has already consented before.

## Solution

Alternatively, you can add the query parameters prompt=consent&access_type=offline to the OAuth redirect (see Google's OAuth 2.0 for Web Server Applications page).

This will prompt the user to authorize the application again and will always return a refresh_token.

## Reference

https://stackoverflow.com/a/10857806/5117552