### PR TITLE
Use a default jsSrc instead of requiring manual set

### DIFF
--- a/src/google-login.js
+++ b/src/google-login.js
@@ -183,8 +183,7 @@ GoogleLogin.defaultProps = {
   },
   icon: true,
   theme: 'light',
-  onRequest: () => {},
-  jsSrc: 'https://apis.google.com/js/api.js'
+  onRequest: () => {}
 }
 
 export default GoogleLogin

--- a/src/load-script.js
+++ b/src/load-script.js
@@ -4,7 +4,7 @@ export default (d, s, id, jsSrc, cb) => {
   let js = element
   js = d.createElement(s)
   js.id = id
-  js.src = jsSrc
+  js.src = jsSrc || 'https://apis.google.com/js/api.js'
   if (fjs && fjs.parentNode) {
     fjs.parentNode.insertBefore(js, fjs)
   } else {


### PR DESCRIPTION
The <GoogleLogin /> component sets a jsSrc prop by default, but the useGoogleLogin hook does not. This pr standardizes that behavior by setting a default jsSrc in load-script.js, with optional override on a component/hook basis. Addresses #318  