### PR TITLE
doc: correct docs around jsSrc and hostedDomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ Use GoogleLogout button to logout the user from google.
 |    params    |   value  |             default value            |   description    |
 |:------------:|:--------:|:------------------------------------:|:----------------:|
 |    clientId  |  string  |               REQUIRED               | You can create a clientID by creating a [new project on Google developers website.](https://developers.google.com/identity/sign-in/web/sign-in) |
-|    jsSrc     |  string  |                   -                  |                  |
-| hostedDomain |  string  |                   -                  | URL of the Javascript file normally hosted by Google |
+|    jsSrc     |  string  |https://apis.google.com/js/api.js|URL of the Javascript file normally hosted by Google|
+| hostedDomain |  string  |                   -                  |The G Suite domain to which users must belong to sign in|
 |     scope    |  string  |             profile email            |                  |
 | responseType |  string  |              permission              | Can be either space-delimited 'id_token', to retrieve an ID Token + 'permission' (or 'token'), to retrieve an Access Token, or 'code', to retrieve an Authorization Code.
 | accessType   |  string  |              online                  | Can be either 'online' or 'offline'. Use offline with responseType 'code' to retrieve an authorization code for fetching a refresh token  |
@@ -174,8 +174,8 @@ Google Scopes List: [scopes](https://developers.google.com/identity/protocols/go
 |    params    |   value  |             default value            |   description    |
 |:------------:|:--------:|:------------------------------------:|:----------------:|
 |    clientId  |  string  |               REQUIRED               | You can create a clientID by creating a [new project on Google developers website.](https://developers.google.com/identity/sign-in/web/sign-in) |
-|    jsSrc     |  string  |                   -                  |                  |
-| hostedDomain |  string  |                   -                  | URL of the Javascript file normally hosted by Google |
+|    jsSrc     |  string  | https://apis.google.com/js/api.js | URL of the Javascript file normally hosted by Google |
+| hostedDomain |  string  |                   -                  | The G Suite domain to which users must belong to sign in |
 |     scope    |  string  |             profile email            |                  |
 | accessType   |  string  |              online                  | Can be either 'online' or 'offline'. Use offline with responseType 'code' to retrieve an authorization code for fetching a refresh token |
 |   onLogoutSuccess  | function |               REQUIRED               |                  |

--- a/stories/google-login-notes.md
+++ b/stories/google-login-notes.md
@@ -57,8 +57,8 @@ If you use the hostedDomain param, make sure to validate the id_token (a JSON we
 |    params    |   value  |             default value            |   description    |
 |:------------:|:--------:|:------------------------------------:|:----------------:|
 |    clientId  |  string  |               REQUIRED               | You can create a clientID by creating a [new project on Google developers website.](https://developers.google.com/identity/sign-in/web/sign-in) |
-|    jsSrc     |  string  |                   -                  |                  |
-| hostedDomain |  string  |                   -                  | URL of the Javascript file normally hosted by Google |
+|    jsSrc     |  string  | https://apis.google.com/js/api.js |URL of the Javascript file normally hosted by Google|
+| hostedDomain |  string  |                   -                  | The G Suite domain to which users must belong to sign in|
 |     scope    |  string  |             profile email            |                  |
 | responseType |  string  |              permission              | Can be either space-delimited 'id_token', to retrieve an ID Token + 'permission' (or 'token'), to retrieve an Access Token, or 'code', to retrieve an Authorization Code.
 | accessType   |  string  |              online                  | Can be either 'online' or 'offline'. Use offline with responseType 'code' to retrieve a refresh token |

--- a/stories/google-logout-notes.md
+++ b/stories/google-logout-notes.md
@@ -71,8 +71,8 @@ Use GoogleLogout button to logout the user from google.
 |    params    |   value  |             default value            |   description    |
 |:------------:|:--------:|:------------------------------------:|:----------------:|
 |    clientId  |  string  |               REQUIRED               | You can create a clientID by creating a [new project on Google developers website.](https://developers.google.com/identity/sign-in/web/sign-in) |
-|    jsSrc     |  string  |                   -                  |                  |
-| hostedDomain |  string  |                   -                  | URL of the Javascript file normally hosted by Google |
+|    jsSrc     |  string  | https://apis.google.com/js/api.js | URL of the Javascript file normally hosted by Google |
+| hostedDomain |  string  |                   -                  |  The G Suite domain to which users must belong to sign in |
 |     scope    |  string  |             profile email            |                  |
 | accessType   |  string  |              online                  | Can be either 'online' or 'offline'. Use offline with responseType 'code' to retrieve a refresh token |
 |   onLogoutSuccess  | function |               REQUIRED               |                  |


### PR DESCRIPTION
First, thanks for the lib.

I think there is some mistakes in the ReadMe regarding the description of the props `jsSrc` and `hostedDomain`. The `jsSrc` description should be the URL where the script is usually hosted, while `hostedDomain` should be the G-suited domain the auth function is limited to https://developers.google.com/identity/sign-in/web/reference#gapiauth2clientconfig.