### PR TITLE
Fix typo in README per #324

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Google Login
 
-> A Google oAUth Sign-in / Log-in Component for React
+> A Google OAuth Sign-in / Log-in Component for React
 
 ## Storybook
 


### PR DESCRIPTION
Replace `oAUth` with `OAuth`