### PR TITLE
Move @types/react into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "homepage": "https://github.com/anthonyjgrove/react-google-login",
   "dependencies": {
-    "@types/react": "*",
     "prop-types": "^15.6.0"
   },
   "devDependencies": {
@@ -61,6 +60,7 @@
     "@storybook/addons": "^5.2.1",
     "@storybook/react": "^5.2.1",
     "@storybook/storybook-deployer": "^2.8.1",
+    "@types/react": "*",
     "autoprefixer": "^9.7.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^24.7.1",


### PR DESCRIPTION
@types/react is only used in TS compilation so should be in devDependencies.