### PR TITLE
useGoogleLogout: Stabilize signOut reference

### DIFF
--- a/src/use-google-logout.js
+++ b/src/use-google-logout.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import loadScript from './load-script'
 import removeScript from './remove-script'
 
@@ -19,14 +19,14 @@ const useGoogleLogout = ({
 }) => {
   const [loaded, setLoaded] = useState(false)
 
-  const signOut = () => {
+  const signOut = useCallback(() => {
     if (window.gapi) {
       const auth2 = window.gapi.auth2.getAuthInstance()
       if (auth2 != null) {
         auth2.signOut().then(auth2.disconnect().then(onLogoutSuccess))
       }
     }
-  }
+  }, [onLogoutSuccess])
 
   useEffect(() => {
     loadScript(document, 'script', 'google-login', jsSrc, () => {


### PR DESCRIPTION
The `signOut` reference returned by `useGoogleLogout()` is unstable, hence it is unusable as a `useEffect()` dependency.