### PR TITLE
Update peer dependencies to support React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,8 +85,8 @@
     "webpack-dev-server": "^3.2.1"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16 || ^17",
+    "react-dom": "^16 || ^17"
   },
   "types": "./index.d.ts",
   "babel": {


### PR DESCRIPTION
I updated to React 17 today and I received the following warning:

```
warning " > react-google-login@5.1.22" has incorrect peer dependency "react@^16.0.0".
warning " > react-google-login@5.1.22" has incorrect peer dependency "react-dom@^16.0.0".
```

However, the package seems to work with the latest React, at least for my usage of it. Here are the release notes: https://reactjs.org/blog/2020/10/20/react-v17.html
