### PR TITLE
Trigger onFailure while api.js load failed

### DIFF
--- a/src/load-script.js
+++ b/src/load-script.js
@@ -1,4 +1,4 @@
-export default (d, s, id, jsSrc, cb) => {
+export default (d, s, id, jsSrc, cb, onError) => {
   const element = d.getElementsByTagName(s)[0]
   const fjs = element
   let js = element
@@ -10,5 +10,6 @@ export default (d, s, id, jsSrc, cb) => {
   } else {
     d.head.appendChild(js)
   }
+  js.onerror = onError
   js.onload = cb
 }

--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -72,66 +72,75 @@ const useGoogleLogin = ({
 
   useEffect(() => {
     let unmounted = false
-    loadScript(document, 'script', 'google-login', jsSrc, () => {
-      const params = {
-        client_id: clientId,
-        cookie_policy: cookiePolicy,
-        login_hint: loginHint,
-        hosted_domain: hostedDomain,
-        fetch_basic_profile: fetchBasicProfile,
-        discoveryDocs,
-        ux_mode: uxMode,
-        redirect_uri: redirectUri,
-        scope,
-        access_type: accessType
-      }
+    loadScript(
+      document,
+      'script',
+      'google-login',
+      jsSrc,
+      () => {
+        const params = {
+          client_id: clientId,
+          cookie_policy: cookiePolicy,
+          login_hint: loginHint,
+          hosted_domain: hostedDomain,
+          fetch_basic_profile: fetchBasicProfile,
+          discoveryDocs,
+          ux_mode: uxMode,
+          redirect_uri: redirectUri,
+          scope,
+          access_type: accessType
+        }
 
-      if (responseType === 'code') {
-        params.access_type = 'offline'
-      }
+        if (responseType === 'code') {
+          params.access_type = 'offline'
+        }
 
-      window.gapi.load('auth2', () => {
-        const GoogleAuth = window.gapi.auth2.getAuthInstance()
-        if (!GoogleAuth) {
-          window.gapi.auth2.init(params).then(
-            res => {
-              if (!unmounted) {
-                setLoaded(true)
-                const signedIn = isSignedIn && res.isSignedIn.get()
-                onAutoLoadFinished(signedIn)
-                if (signedIn) {
-                  handleSigninSuccess(res.currentUser.get())
+        window.gapi.load('auth2', () => {
+          const GoogleAuth = window.gapi.auth2.getAuthInstance()
+          if (!GoogleAuth) {
+            window.gapi.auth2.init(params).then(
+              res => {
+                if (!unmounted) {
+                  setLoaded(true)
+                  const signedIn = isSignedIn && res.isSignedIn.get()
+                  onAutoLoadFinished(signedIn)
+                  if (signedIn) {
+                    handleSigninSuccess(res.currentUser.get())
+                  }
                 }
-              }
-            },
-            err => {
-              setLoaded(true)
-              onAutoLoadFinished(false)
-              onFailure(err)
-            }
-          )
-        } else {
-          GoogleAuth.then(
-            () => {
-              if (unmounted) {
-                return
-              }
-              if (isSignedIn && GoogleAuth.isSignedIn.get()) {
-                setLoaded(true)
-                onAutoLoadFinished(true)
-                handleSigninSuccess(GoogleAuth.currentUser.get())
-              } else {
+              },
+              err => {
                 setLoaded(true)
                 onAutoLoadFinished(false)
+                onFailure(err)
               }
-            },
-            err => {
-              onFailure(err)
-            }
-          )
-        }
-      })
-    })
+            )
+          } else {
+            GoogleAuth.then(
+              () => {
+                if (unmounted) {
+                  return
+                }
+                if (isSignedIn && GoogleAuth.isSignedIn.get()) {
+                  setLoaded(true)
+                  onAutoLoadFinished(true)
+                  handleSigninSuccess(GoogleAuth.currentUser.get())
+                } else {
+                  setLoaded(true)
+                  onAutoLoadFinished(false)
+                }
+              },
+              err => {
+                onFailure(err)
+              }
+            )
+          }
+        })
+      },
+      err => {
+        onFailure(err)
+      }
+    )
 
     return () => {
       unmounted = true

--- a/src/use-google-logout.js
+++ b/src/use-google-logout.js
@@ -37,30 +37,39 @@ const useGoogleLogout = ({
   }, [onLogoutSuccess])
 
   useEffect(() => {
-    loadScript(document, 'script', 'google-login', jsSrc, () => {
-      const params = {
-        client_id: clientId,
-        cookie_policy: cookiePolicy,
-        login_hint: loginHint,
-        hosted_domain: hostedDomain,
-        fetch_basic_profile: fetchBasicProfile,
-        discoveryDocs,
-        ux_mode: uxMode,
-        redirect_uri: redirectUri,
-        scope,
-        access_type: accessType
-      }
-      window.gapi.load('auth2', () => {
-        if (!window.gapi.auth2.getAuthInstance()) {
-          window.gapi.auth2.init(params).then(
-            () => setLoaded(true),
-            err => onFailure(err)
-          )
-        } else {
-          setLoaded(true)
+    loadScript(
+      document,
+      'script',
+      'google-login',
+      jsSrc,
+      () => {
+        const params = {
+          client_id: clientId,
+          cookie_policy: cookiePolicy,
+          login_hint: loginHint,
+          hosted_domain: hostedDomain,
+          fetch_basic_profile: fetchBasicProfile,
+          discoveryDocs,
+          ux_mode: uxMode,
+          redirect_uri: redirectUri,
+          scope,
+          access_type: accessType
         }
-      })
-    })
+        window.gapi.load('auth2', () => {
+          if (!window.gapi.auth2.getAuthInstance()) {
+            window.gapi.auth2.init(params).then(
+              () => setLoaded(true),
+              err => onFailure(err)
+            )
+          } else {
+            setLoaded(true)
+          }
+        })
+      },
+      err => {
+        onFailure(err)
+      }
+    )
 
     return () => {
       removeScript(document, 'google-login')


### PR DESCRIPTION
It's for https://github.com/anthonyjgrove/react-google-login/issues/400.
Just listen to the error event of loading script and trigger `onFailure` if loading failed.