### PR TITLE
Add optional argument to getAuthResponse

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 // Type definitions for react-google-login v2.5.4
 // Project: https://github.com/anthonyjgrove/react-google-login
 // Definitions by: Ruslan Ibragimov <https://github.com/IRus>
-import { Component, ReactNode, CSSProperties } from "react";
+import {Component, ReactNode, CSSProperties} from 'react';
 
 export as namespace ReactGoogleLogin;
 
@@ -36,9 +36,7 @@ export interface GoogleLoginResponse {
   isSignedIn(): boolean;
   hasGrantedScopes(scopes: string): boolean;
   disconnect(): void;
-  grantOfflineAccess(
-    options: GrantOfflineAccessOptions
-  ): Promise<GoogleLoginResponseOffline>;
+  grantOfflineAccess(options: GrantOfflineAccessOptions): Promise<GoogleLoginResponseOffline>;
   signIn(options: SignInOptions): Promise<any>;
   grant(options: SignInOptions): Promise<any>;
   // google-login.js sez: offer renamed response keys to names that match use
@@ -46,7 +44,7 @@ export interface GoogleLoginResponse {
   tokenObj: AuthResponse;
   tokenId: string;
   accessToken: string;
-  readonly code?: string; //does not exist but here to satisfy typescript compatibility
+  readonly code?: string;//does not exist but here to satisfy typescript compatibility
   profileObj: {
     googleId: string;
     imageUrl: string;
@@ -54,7 +52,7 @@ export interface GoogleLoginResponse {
     name: string;
     givenName: string;
     familyName: string;
-  };
+  }
 }
 
 interface GrantOfflineAccessOptions {
@@ -74,28 +72,26 @@ export interface GoogleLoginResponseOffline {
 }
 
 export interface GoogleLoginProps {
-  readonly onSuccess?: (
-    response: GoogleLoginResponse | GoogleLoginResponseOffline
-  ) => void;
-  readonly onAutoLoadFinished?: (successLogin: boolean) => void;
-  readonly onFailure?: (error: any) => void;
-  readonly onRequest?: () => void;
-  readonly clientId: string;
-  readonly jsSrc?: string;
-  readonly buttonText?: string;
-  readonly scope?: string;
-  readonly className?: string;
-  readonly redirectUri?: string;
-  readonly cookiePolicy?: string;
-  readonly loginHint?: string;
-  readonly hostedDomain?: string;
-  readonly prompt?: string;
-  readonly responseType?: string;
-  readonly children?: ReactNode;
-  readonly style?: CSSProperties;
-  readonly icon?: boolean;
-  readonly theme?: "light" | "dark";
-  readonly tag?: string;
+  readonly onSuccess?: (response: GoogleLoginResponse | GoogleLoginResponseOffline) => void,
+  readonly onAutoLoadFinished?: (successLogin: boolean) => void,
+  readonly onFailure?: (error: any) => void,
+  readonly onRequest?: () => void,
+  readonly clientId: string,
+  readonly jsSrc?: string,
+  readonly buttonText?: string,
+  readonly scope?: string,
+  readonly className?: string,
+  readonly redirectUri?: string,
+  readonly cookiePolicy?: string,
+  readonly loginHint?: string,
+  readonly hostedDomain?: string,
+  readonly prompt?: string,
+  readonly responseType?: string,
+  readonly children?: ReactNode,
+  readonly style?: CSSProperties,
+  readonly icon?: boolean,
+  readonly theme?: "light" | "dark",
+  readonly tag?: string,
   readonly disabled?: boolean;
   readonly autoLoad?: boolean;
   readonly uxMode?: string;
@@ -104,10 +100,7 @@ export interface GoogleLoginProps {
   readonly isSignedIn?: boolean;
   readonly type?: string;
   readonly accessType?: string;
-  readonly render?: (props: {
-    onClick: () => void;
-    disabled?: boolean;
-  }) => JSX.Element;
+  readonly render?: (props: { onClick: () => void, disabled?: boolean }) => JSX.Element;
 }
 
 export class GoogleLogin extends Component<GoogleLoginProps, unknown> {
@@ -115,7 +108,7 @@ export class GoogleLogin extends Component<GoogleLoginProps, unknown> {
 }
 
 export interface GoogleLogoutProps {
-  readonly clientId: string;
+  readonly clientId: string,
   readonly onLogoutSuccess?: () => void;
   readonly onFailure?: () => void;
   readonly buttonText?: string;
@@ -123,27 +116,24 @@ export interface GoogleLogoutProps {
   readonly children?: ReactNode;
   readonly jsSrc?: string;
   readonly style?: CSSProperties;
-  readonly icon?: boolean;
+  readonly icon?: boolean,
   readonly disabled?: boolean;
   readonly disabledStyle?: CSSProperties;
   readonly tag?: string;
-  readonly render?: (props: {
-    onClick: () => void;
-    disabled?: boolean;
-  }) => JSX.Element;
+  readonly render?: (props: { onClick: () => void, disabled?: boolean }) => JSX.Element;
 }
 
 export class GoogleLogout extends Component<GoogleLogoutProps, unknown> {
   public signOut(): void;
 }
 
-export interface UseGoogleLogoutResponse {
+export interface UseGoogleLogoutResponse { 
   signOut: () => void;
   loaded: boolean;
 }
 
-export interface UseGoogleLogoutProps {
-  readonly clientId: string;
+export interface UseGoogleLogoutProps { 
+  readonly clientId: string,
   readonly onLogoutSuccess?: () => void;
   readonly onFailure?: () => void;
   readonly accessType?: string;
@@ -151,38 +141,34 @@ export interface UseGoogleLogoutProps {
   readonly cookiePolicy?: string;
   readonly loginHint?: string;
   readonly hostedDomain?: string;
-  readonly redirectUri?: string;
+  readonly redirectUri?: string,
   readonly discoveryDocs?: any;
-  readonly scope?: string;
+  readonly scope?: string,
   readonly uxMode?: string;
   readonly jsSrc?: string;
 }
 
-export function useGoogleLogout(
-  input: UseGoogleLogoutProps
-): UseGoogleLogoutResponse;
+export function useGoogleLogout(input: UseGoogleLogoutProps): UseGoogleLogoutResponse;
 
-export interface UseGoogleLoginResponse {
+export interface UseGoogleLoginResponse { 
   signIn: () => void;
   loaded: boolean;
 }
 
-export interface UseGoogleLoginProps {
-  readonly onSuccess?: (
-    response: GoogleLoginResponse | GoogleLoginResponseOffline
-  ) => void;
-  readonly onFailure?: (error: any) => void;
-  readonly onAutoLoadFinished?: (successLogin: boolean) => void;
-  readonly clientId: string;
-  readonly jsSrc?: string;
-  readonly onRequest?: () => void;
-  readonly scope?: string;
-  readonly redirectUri?: string;
-  readonly cookiePolicy?: string;
-  readonly loginHint?: string;
-  readonly hostedDomain?: string;
-  readonly prompt?: string;
-  readonly responseType?: string;
+export interface UseGoogleLoginProps { 
+  readonly onSuccess?: (response: GoogleLoginResponse | GoogleLoginResponseOffline) => void,
+  readonly onFailure?: (error: any) => void,
+  readonly onAutoLoadFinished?: (successLogin: boolean) => void,
+  readonly clientId: string,
+  readonly jsSrc?: string,
+  readonly onRequest?: () => void,
+  readonly scope?: string,
+  readonly redirectUri?: string,
+  readonly cookiePolicy?: string,
+  readonly loginHint?: string,
+  readonly hostedDomain?: string,
+  readonly prompt?: string,
+  readonly responseType?: string,
   readonly autoLoad?: boolean;
   readonly uxMode?: string;
   readonly fetchBasicProfile?: boolean;
@@ -191,8 +177,6 @@ export interface UseGoogleLoginProps {
   readonly accessType?: string;
 }
 
-export function useGoogleLogin(
-  input: UseGoogleLoginProps
-): UseGoogleLoginResponse;
+export function useGoogleLogin(input: UseGoogleLoginProps): UseGoogleLoginResponse;
 
 export default GoogleLogin;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 // Type definitions for react-google-login v2.5.4
 // Project: https://github.com/anthonyjgrove/react-google-login
 // Definitions by: Ruslan Ibragimov <https://github.com/IRus>
-import {Component, ReactNode, CSSProperties} from 'react';
+import { Component, ReactNode, CSSProperties } from "react";
 
 export as namespace ReactGoogleLogin;
 
@@ -28,7 +28,7 @@ interface BasicProfile {
 // Based on https://developers.google.com/identity/sign-in/web/reference
 export interface GoogleLoginResponse {
   getBasicProfile(): BasicProfile;
-  getAuthResponse(): AuthResponse;
+  getAuthResponse(includeAuthorizationData?: boolean): AuthResponse;
   reloadAuthResponse(): Promise<AuthResponse>;
   getGrantedScopes(): string;
   getHostedDomain(): string;
@@ -36,7 +36,9 @@ export interface GoogleLoginResponse {
   isSignedIn(): boolean;
   hasGrantedScopes(scopes: string): boolean;
   disconnect(): void;
-  grantOfflineAccess(options: GrantOfflineAccessOptions): Promise<GoogleLoginResponseOffline>;
+  grantOfflineAccess(
+    options: GrantOfflineAccessOptions
+  ): Promise<GoogleLoginResponseOffline>;
   signIn(options: SignInOptions): Promise<any>;
   grant(options: SignInOptions): Promise<any>;
   // google-login.js sez: offer renamed response keys to names that match use
@@ -44,7 +46,7 @@ export interface GoogleLoginResponse {
   tokenObj: AuthResponse;
   tokenId: string;
   accessToken: string;
-  readonly code?: string;//does not exist but here to satisfy typescript compatibility
+  readonly code?: string; //does not exist but here to satisfy typescript compatibility
   profileObj: {
     googleId: string;
     imageUrl: string;
@@ -52,7 +54,7 @@ export interface GoogleLoginResponse {
     name: string;
     givenName: string;
     familyName: string;
-  }
+  };
 }
 
 interface GrantOfflineAccessOptions {
@@ -72,26 +74,28 @@ export interface GoogleLoginResponseOffline {
 }
 
 export interface GoogleLoginProps {
-  readonly onSuccess?: (response: GoogleLoginResponse | GoogleLoginResponseOffline) => void,
-  readonly onAutoLoadFinished?: (successLogin: boolean) => void,
-  readonly onFailure?: (error: any) => void,
-  readonly onRequest?: () => void,
-  readonly clientId: string,
-  readonly jsSrc?: string,
-  readonly buttonText?: string,
-  readonly scope?: string,
-  readonly className?: string,
-  readonly redirectUri?: string,
-  readonly cookiePolicy?: string,
-  readonly loginHint?: string,
-  readonly hostedDomain?: string,
-  readonly prompt?: string,
-  readonly responseType?: string,
-  readonly children?: ReactNode,
-  readonly style?: CSSProperties,
-  readonly icon?: boolean,
-  readonly theme?: "light" | "dark",
-  readonly tag?: string,
+  readonly onSuccess?: (
+    response: GoogleLoginResponse | GoogleLoginResponseOffline
+  ) => void;
+  readonly onAutoLoadFinished?: (successLogin: boolean) => void;
+  readonly onFailure?: (error: any) => void;
+  readonly onRequest?: () => void;
+  readonly clientId: string;
+  readonly jsSrc?: string;
+  readonly buttonText?: string;
+  readonly scope?: string;
+  readonly className?: string;
+  readonly redirectUri?: string;
+  readonly cookiePolicy?: string;
+  readonly loginHint?: string;
+  readonly hostedDomain?: string;
+  readonly prompt?: string;
+  readonly responseType?: string;
+  readonly children?: ReactNode;
+  readonly style?: CSSProperties;
+  readonly icon?: boolean;
+  readonly theme?: "light" | "dark";
+  readonly tag?: string;
   readonly disabled?: boolean;
   readonly autoLoad?: boolean;
   readonly uxMode?: string;
@@ -100,7 +104,10 @@ export interface GoogleLoginProps {
   readonly isSignedIn?: boolean;
   readonly type?: string;
   readonly accessType?: string;
-  readonly render?: (props: { onClick: () => void, disabled?: boolean }) => JSX.Element;
+  readonly render?: (props: {
+    onClick: () => void;
+    disabled?: boolean;
+  }) => JSX.Element;
 }
 
 export class GoogleLogin extends Component<GoogleLoginProps, unknown> {
@@ -108,7 +115,7 @@ export class GoogleLogin extends Component<GoogleLoginProps, unknown> {
 }
 
 export interface GoogleLogoutProps {
-  readonly clientId: string,
+  readonly clientId: string;
   readonly onLogoutSuccess?: () => void;
   readonly onFailure?: () => void;
   readonly buttonText?: string;
@@ -116,24 +123,27 @@ export interface GoogleLogoutProps {
   readonly children?: ReactNode;
   readonly jsSrc?: string;
   readonly style?: CSSProperties;
-  readonly icon?: boolean,
+  readonly icon?: boolean;
   readonly disabled?: boolean;
   readonly disabledStyle?: CSSProperties;
   readonly tag?: string;
-  readonly render?: (props: { onClick: () => void, disabled?: boolean }) => JSX.Element;
+  readonly render?: (props: {
+    onClick: () => void;
+    disabled?: boolean;
+  }) => JSX.Element;
 }
 
 export class GoogleLogout extends Component<GoogleLogoutProps, unknown> {
   public signOut(): void;
 }
 
-export interface UseGoogleLogoutResponse { 
+export interface UseGoogleLogoutResponse {
   signOut: () => void;
   loaded: boolean;
 }
 
-export interface UseGoogleLogoutProps { 
-  readonly clientId: string,
+export interface UseGoogleLogoutProps {
+  readonly clientId: string;
   readonly onLogoutSuccess?: () => void;
   readonly onFailure?: () => void;
   readonly accessType?: string;
@@ -141,34 +151,38 @@ export interface UseGoogleLogoutProps {
   readonly cookiePolicy?: string;
   readonly loginHint?: string;
   readonly hostedDomain?: string;
-  readonly redirectUri?: string,
+  readonly redirectUri?: string;
   readonly discoveryDocs?: any;
-  readonly scope?: string,
+  readonly scope?: string;
   readonly uxMode?: string;
   readonly jsSrc?: string;
 }
 
-export function useGoogleLogout(input: UseGoogleLogoutProps): UseGoogleLogoutResponse;
+export function useGoogleLogout(
+  input: UseGoogleLogoutProps
+): UseGoogleLogoutResponse;
 
-export interface UseGoogleLoginResponse { 
+export interface UseGoogleLoginResponse {
   signIn: () => void;
   loaded: boolean;
 }
 
-export interface UseGoogleLoginProps { 
-  readonly onSuccess?: (response: GoogleLoginResponse | GoogleLoginResponseOffline) => void,
-  readonly onFailure?: (error: any) => void,
-  readonly onAutoLoadFinished?: (successLogin: boolean) => void,
-  readonly clientId: string,
-  readonly jsSrc?: string,
-  readonly onRequest?: () => void,
-  readonly scope?: string,
-  readonly redirectUri?: string,
-  readonly cookiePolicy?: string,
-  readonly loginHint?: string,
-  readonly hostedDomain?: string,
-  readonly prompt?: string,
-  readonly responseType?: string,
+export interface UseGoogleLoginProps {
+  readonly onSuccess?: (
+    response: GoogleLoginResponse | GoogleLoginResponseOffline
+  ) => void;
+  readonly onFailure?: (error: any) => void;
+  readonly onAutoLoadFinished?: (successLogin: boolean) => void;
+  readonly clientId: string;
+  readonly jsSrc?: string;
+  readonly onRequest?: () => void;
+  readonly scope?: string;
+  readonly redirectUri?: string;
+  readonly cookiePolicy?: string;
+  readonly loginHint?: string;
+  readonly hostedDomain?: string;
+  readonly prompt?: string;
+  readonly responseType?: string;
   readonly autoLoad?: boolean;
   readonly uxMode?: string;
   readonly fetchBasicProfile?: boolean;
@@ -177,6 +191,8 @@ export interface UseGoogleLoginProps {
   readonly accessType?: string;
 }
 
-export function useGoogleLogin(input: UseGoogleLoginProps): UseGoogleLoginResponse;
+export function useGoogleLogin(
+  input: UseGoogleLoginProps
+): UseGoogleLoginResponse;
 
 export default GoogleLogin;


### PR DESCRIPTION
Adds optional `includeAuthorizationData` boolean to getAuthResponse in the GoogleLoginResponse interface to match the underlying type in the Google API ([API documentation here](https://developers.google.com/identity/sign-in/web/reference#googleusergetauthresponseincludeauthorizationdata))
Currently, it is necessary to use a `@ts-ignore` directive when using the argument