### PR TITLE
Add 'onScriptLoadFailure' function to useGoogleLogout hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Use GoogleLogout button to logout the user from google.
 | accessType   |  string  |              online                  | Can be either 'online' or 'offline'. Use offline with responseType 'code' to retrieve an authorization code for fetching a refresh token  |
 |   onSuccess  | function |               REQUIRED               |                  |
 |   onFailure  | function |               REQUIRED               |                  |
+|   onScriptLoadFailure  | function |         -                  | If defined, will be called when loading the 'google-login' script fails (otherwise onFailure will be called) |
 |   onRequest  | function |                   -                  |                  |
 |   onAutoLoadFinished  | function |                   -         |                  |
 |   buttonText |  string  |             Login with Google        |                  |
@@ -180,6 +181,7 @@ Google Scopes List: [scopes](https://developers.google.com/identity/protocols/go
 | accessType   |  string  |              online                  | Can be either 'online' or 'offline'. Use offline with responseType 'code' to retrieve an authorization code for fetching a refresh token |
 |   onLogoutSuccess  | function |               REQUIRED               |                  |
 |   onFailure  | function |               REQUIRED               |                  |
+|   onScriptLoadFailure  | function |         -                  | If defined, will be called when loading the 'google-login' script fails (otherwise onFailure will be called) |
 |   buttonText |  string  |             Logout of Google        |                  |
 |   className  |  string  |                   -                  |                  |
 | disabledStyle|  object  |                   -                  |                  |

--- a/index.d.ts
+++ b/index.d.ts
@@ -75,6 +75,7 @@ export interface GoogleLoginProps {
   readonly onSuccess?: (response: GoogleLoginResponse | GoogleLoginResponseOffline) => void,
   readonly onAutoLoadFinished?: (successLogin: boolean) => void,
   readonly onFailure?: (error: any) => void,
+  readonly onSciptLoadFailure?: (error: any) => void,
   readonly onRequest?: () => void,
   readonly clientId: string,
   readonly jsSrc?: string,
@@ -158,6 +159,7 @@ export interface UseGoogleLoginResponse {
 export interface UseGoogleLoginProps { 
   readonly onSuccess?: (response: GoogleLoginResponse | GoogleLoginResponseOffline) => void,
   readonly onFailure?: (error: any) => void,
+  readonly onSciptLoadFailure?: (error: any) => void,
   readonly onAutoLoadFinished?: (successLogin: boolean) => void,
   readonly clientId: string,
   readonly jsSrc?: string,

--- a/src/google-login.js
+++ b/src/google-login.js
@@ -12,6 +12,7 @@ const GoogleLogin = props => {
     onAutoLoadFinished,
     onRequest,
     onFailure,
+    onScriptLoadFailure,
     tag,
     type,
     className,
@@ -44,6 +45,7 @@ const GoogleLogin = props => {
     onAutoLoadFinished,
     onRequest,
     onFailure,
+    onScriptLoadFailure,
     clientId,
     cookiePolicy,
     loginHint,
@@ -141,6 +143,7 @@ const GoogleLogin = props => {
 GoogleLogin.propTypes = {
   onSuccess: PropTypes.func.isRequired,
   onFailure: PropTypes.func.isRequired,
+  onScriptLoadFailure: PropTypes.func,
   clientId: PropTypes.string.isRequired,
   jsSrc: PropTypes.string,
   onRequest: PropTypes.func,

--- a/src/google-logout.js
+++ b/src/google-logout.js
@@ -27,6 +27,7 @@ const GoogleLogout = props => {
     redirectUri,
     discoveryDocs,
     onFailure,
+    onScriptLoadFailure,
     uxMode,
     scope,
     accessType,
@@ -36,6 +37,7 @@ const GoogleLogout = props => {
   const { signOut, loaded } = useGoogleLogout({
     jsSrc,
     onFailure,
+    onScriptLoadFailure,
     clientId,
     cookiePolicy,
     loginHint,

--- a/src/google-logout.js
+++ b/src/google-logout.js
@@ -140,7 +140,9 @@ GoogleLogout.propTypes = {
   type: PropTypes.string,
   render: PropTypes.func,
   theme: PropTypes.string,
-  icon: PropTypes.bool
+  icon: PropTypes.bool,
+  onFailure: PropTypes.func,
+  onScriptLoadFailure: PropTypes.func
 }
 
 GoogleLogout.defaultProps = {

--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -7,6 +7,7 @@ const useGoogleLogin = ({
   onAutoLoadFinished = () => {},
   onFailure = () => {},
   onRequest = () => {},
+  onScriptLoadFailure,
   clientId,
   cookiePolicy,
   loginHint,
@@ -72,6 +73,7 @@ const useGoogleLogin = ({
 
   useEffect(() => {
     let unmounted = false
+    const onLoadFailure = onScriptLoadFailure || onFailure
     loadScript(
       document,
       'script',
@@ -112,7 +114,7 @@ const useGoogleLogin = ({
               err => {
                 setLoaded(true)
                 onAutoLoadFinished(false)
-                onFailure(err)
+                onLoadFailure(err)
               }
             )
           } else {
@@ -138,7 +140,7 @@ const useGoogleLogin = ({
         })
       },
       err => {
-        onFailure(err)
+        onLoadFailure(err)
       }
     )
 

--- a/src/use-google-logout.js
+++ b/src/use-google-logout.js
@@ -5,6 +5,7 @@ import removeScript from './remove-script'
 const useGoogleLogout = ({
   jsSrc = 'https://apis.google.com/js/api.js',
   onFailure,
+  onScriptLoadFailure,
   clientId,
   cookiePolicy,
   loginHint,
@@ -37,6 +38,7 @@ const useGoogleLogout = ({
   }, [onLogoutSuccess])
 
   useEffect(() => {
+    const onLoadFailure = onScriptLoadFailure || onFailure
     loadScript(
       document,
       'script',
@@ -59,7 +61,7 @@ const useGoogleLogout = ({
           if (!window.gapi.auth2.getAuthInstance()) {
             window.gapi.auth2.init(params).then(
               () => setLoaded(true),
-              err => onFailure(err)
+              err => onLoadFailure(err)
             )
           } else {
             setLoaded(true)
@@ -67,7 +69,7 @@ const useGoogleLogout = ({
         })
       },
       err => {
-        onFailure(err)
+        onLoadFailure(err)
       }
     )
 


### PR DESCRIPTION
### Motivation
I want to know when the script loading has failed for google logout, but I need to be able to differentiate this from a failure trying to _call_ logout. 

For example, if a user tries to logout and it fails, we show them an error toast - this doesn't make sense when the script has failed to load.

This PR adds a new function for script loading specifically, but defaults to the current failure handler - meaning that this shouldn't be a breaking change 🙏