### PR TITLE
Allow async client-id retrieval for login hook

### DIFF
--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -73,7 +73,7 @@ const useGoogleLogin = ({
 
   useEffect(() => {
     if (!clientId) {
-      return
+      return null
     }
     let unmounted = false
     const onLoadFailure = onScriptLoadFailure || onFailure

--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -72,6 +72,7 @@ const useGoogleLogin = ({
   }
 
   useEffect(() => {
+    if (!clientId) return
     let unmounted = false
     const onLoadFailure = onScriptLoadFailure || onFailure
     loadScript(
@@ -148,7 +149,7 @@ const useGoogleLogin = ({
       unmounted = true
       removeScript(document, 'google-login')
     }
-  }, [])
+  }, [clientId])
 
   useEffect(() => {
     if (autoLoad) {

--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -72,7 +72,9 @@ const useGoogleLogin = ({
   }
 
   useEffect(() => {
-    if (!clientId) return
+    if (!clientId) {
+      return
+    }
     let unmounted = false
     const onLoadFailure = onScriptLoadFailure || onFailure
     loadScript(

--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -73,7 +73,7 @@ const useGoogleLogin = ({
 
   useEffect(() => {
     if (!clientId) {
-      return null
+      return () => null
     }
     let unmounted = false
     const onLoadFailure = onScriptLoadFailure || onFailure


### PR DESCRIPTION
At the moment, if client-id is received asynchronously and is null at the beginning, the hook will throw error on loading the google script. This patch introduce clientId as a dependency to the useEffect, which allow the hook to response to changes to the client-id and init the login script. 