### PR TITLE
Fix UseGoogleLogoutProps typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -136,7 +136,8 @@ export interface UseGoogleLogoutResponse {
 export interface UseGoogleLogoutProps { 
   readonly clientId: string,
   readonly onLogoutSuccess?: () => void;
-  readonly onFailure?: () => void;
+  readonly onFailure?: (reason: {error: string, details: string}) => any;
+  readonly onScriptLoadFailure?: (reason: {error: string, details: string}) => any;
   readonly accessType?: string;
   readonly fetchBasicProfile?: boolean;
   readonly cookiePolicy?: string;


### PR DESCRIPTION
There are two changes related to error handling in UserGoogleLogoutProps:

1. Added onScriptLoadFailure callback, which is used in [js code](https://github.com/anthonyjgrove/react-google-login/blob/7db5b9686a70ded6b090a9c01906ca978b00a54d/src/use-google-logout.js#L41)
2. Added error types for both onFailure and onScriptLoadFailure, according to [gapi.auth2 type definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d04cd9a404f26b5fff022281f9e5bcbcb8f29114/types/gapi.auth2/index.d.ts#L24)