### PR TITLE
feature: add 'addScopes' to useGoogleLogout hook to support incremental scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,12 +270,10 @@ request the user to authorizes only the new scopes from a consent screen.
 
 You can use `addScopes` from `useGoogleLogin` hook to request additional scopes
 with `cliendId`, `onAddScopesSuccess`, and `onAddScopesFailure` as shown in the
-example.
+example. If you want to grant offline access to the new scopes, don't forget to
+also include `responseType: 'code'` and `promp: 'consent'`.
 
-NOTE: It would only run if `signIn` or `GoogleLogin` button was used before and
-the user is logged in. For this reason, `isSignedIn` should be set to `true` in
-the first signin attempt or initialization.
-
+NOTE: `addScopes` can only be used if the user is already logged in.
 
 ```js
 import { useGoogleLogin } from 'react-google-login'
@@ -289,6 +287,7 @@ const { addScopes } = useGoogleLogin({
 
 More details about this workflow can be found in the official Google docs:
  * [Requesting additional permissions](https://developers.google.com/identity/sign-in/web/incremental-auth)
+
 
 ### onAddScopesSuccess callback
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ ReactDOM.render(
 ```js
 import { useGoogleLogin } from 'react-google-login'
 
-const { signIn, loaded } = useGoogleLogin({
+const { signIn, addScopes, loaded } = useGoogleLogin({
     onSuccess,
     onAutoLoadFinished,
     clientId,
@@ -109,6 +109,7 @@ const { signOut, loaded } = useGoogleLogout({
     onLogoutSuccess
   })
 ```
+
 ## onSuccess callback
 
 If responseType is not 'code', callback will return the GoogleAuth object.
@@ -246,7 +247,6 @@ onFailure callback is called when either initialization or a signin attempt fail
 |   details     |  string  |      Detailed error description      |
 
 
-
 Common error codes include:
 
 | error code | description |
@@ -260,6 +260,48 @@ More details can be found in the official Google docs:
  * [GoogleAuth.then(onInit, onError)](https://developers.google.com/identity/sign-in/web/reference#googleauththenoninit-onerror)
  * [GoogleAuth.signIn(options)](https://developers.google.com/identity/sign-in/web/reference#googleauthsigninoptions)
  * [GoogleAuth.grantOfflineAccess(options)](https://developers.google.com/identity/sign-in/web/reference#googleauthgrantofflineaccessoptions)
+
+
+## Request Additional Scopes
+
+At sign-in, your application requests "base" scopes such as "profile email". If
+the user wants to perform an action that requires additional scopes, your app can
+request the user to authorizes only the new scopes from a consent screen.
+
+You can use `addScopes` from `useGoogleLogin` hook to request additional scopes
+with `cliendId`, `onAddScopesSuccess`, and `onAddScopesFailure` as shown in the
+example.
+
+NOTE: It would only run if `signIn` or `GoogleLogin` button was used before and
+the user is logged in. For this reason, `isSignedIn` should be set to `true` in
+the first signin attempt or initialization.
+
+
+```js
+import { useGoogleLogin } from 'react-google-login'
+
+const { addScopes } = useGoogleLogin({
+  clientId,
+  onAddScopesSuccess,
+  onAddScopesSuccess
+})
+```
+
+More details about this workflow can be found in the official Google docs:
+ * [Requesting additional permissions](https://developers.google.com/identity/sign-in/web/incremental-auth)
+
+### onAddScopesSuccess callback
+
+onAddScopesSuccess should be set when you request additional scopes. This callback returns a GoogleUser object which provides access to all of
+the GoogleUser properties listed in the above [onSuccess callback section](#onsuccess-callback--w-offline-false).
+
+
+## onAddScopesFailure callback
+
+onAddScopesSuccess is called when the additional scope request fails.
+
+See properties and common errors in [onFailure callback section](#onfailure-callback).
+
 
 ## Dev Server
 ```

--- a/demo/app.js
+++ b/demo/app.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { GoogleLogout, GoogleLogin } from '../src/index'
+import { GoogleLogout, GoogleLogin, useGoogleLogin } from '../src/index'
 // import GoogleLogin, { GoogleLogout } from '../dist/google-login'
 // import FontAwesome from 'react-fontawesome';
 
@@ -42,59 +42,70 @@ const MountTest = () => {
   return <button onClick={() => toggleShow(true)}>show button</button>
 }
 
-export default () => (
-  <div>
-    <MountTest />
-    <br />
-    <br />
-    <GoogleLogin
-      clientId={clientId}
-      scope="https://www.googleapis.com/auth/analytics"
-      onSuccess={success}
-      onFailure={error}
-      onRequest={loading}
-      offline={false}
-      approvalPrompt="force"
-      responseType="id_token"
-      isSignedIn
-      theme="dark"
-      // disabled
-      // prompt="consent"
-      // className='button'
-      // style={{ color: 'red' }}
-    >
-      <span>Analytics</span>
-    </GoogleLogin>
-    <br />
-    <br />
-    <GoogleLogin
-      clientId={clientId}
-      scope="https://www.googleapis.com/auth/adwords"
-      onSuccess={success}
-      onFailure={error}
-      onRequest={loading}
-      approvalPrompt="force"
-      responseType="code"
-      // uxMode="redirect"
-      // redirectUri="http://google.com"
-      // disabled
-      // prompt="consent"
-      // className='button'
-      // style={{ color: 'red' }}
-    >
-      <span>Adwords</span>
-    </GoogleLogin>
-    <br />
-    <br />
-    <GoogleLogin onSuccess={success} onFailure={error} clientId={clientId} />
-    <br />
-    <br />
-    <GoogleLogin theme="dark" onSuccess={success} onFailure={error} clientId={clientId} />
-    <br />
-    <br />
-    <GoogleLogin theme="dark" style={{ background: 'blue' }} onSuccess={success} onFailure={error} clientId={clientId} />
-    <br />
-    <br />
-    <GoogleLogout buttonText="Logout" onLogoutSuccess={logout} />
-  </div>
-)
+export default () => {
+  const { addScopes } = useGoogleLogin({
+    clientId,
+    onAddScopesSuccess: success,
+    onAddScopesFailure: error
+  })
+
+  return (
+    <div>
+      <MountTest />
+      <br />
+      <br />
+      <GoogleLogin
+        clientId={clientId}
+        scope="https://www.googleapis.com/auth/analytics"
+        onSuccess={success}
+        onFailure={error}
+        onRequest={loading}
+        offline={false}
+        approvalPrompt="force"
+        responseType="id_token"
+        isSignedIn
+        theme="dark"
+        // disabled
+        // prompt="consent"
+        // className='button'
+        // style={{ color: 'red' }}
+      >
+        <span>Analytics</span>
+      </GoogleLogin>
+      <br />
+      <br />
+      <GoogleLogin
+        clientId={clientId}
+        scope="https://www.googleapis.com/auth/adwords"
+        onSuccess={success}
+        onFailure={error}
+        onRequest={loading}
+        approvalPrompt="force"
+        responseType="code"
+        // uxMode="redirect"
+        // redirectUri="http://google.com"
+        // disabled
+        // prompt="consent"
+        // className='button'
+        // style={{ color: 'red' }}
+      >
+        <span>Adwords</span>
+      </GoogleLogin>
+      <br />
+      <br />
+      <GoogleLogin onSuccess={success} onFailure={error} clientId={clientId} />
+      <br />
+      <br />
+      <GoogleLogin theme="dark" onSuccess={success} onFailure={error} clientId={clientId} />
+      <br />
+      <br />
+      <GoogleLogin theme="dark" style={{ background: 'blue' }} onSuccess={success} onFailure={error} clientId={clientId} />
+      <br />
+      <br />
+      <button onClick={() => addScopes('https://www.googleapis.com/auth/calendar')}>Request Additional Scopes</button>
+      <br />
+      <br />
+      <GoogleLogout buttonText="Logout" onLogoutSuccess={logout} />
+    </div>
+  )
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -160,7 +160,7 @@ export interface UseGoogleLoginResponse {
 export interface UseGoogleLoginProps {
   readonly onSuccess?: (response: GoogleLoginResponse | GoogleLoginResponseOffline) => void,
   readonly onFailure?: (error: any) => void,
-  readonly onAddScopesSuccess?: (response: GoogleLoginResponse) => void,
+  readonly onAddScopesSuccess?: (response: GoogleLoginResponse | GoogleLoginResponseOffline) => void,
   readonly onAddScopesFailure?: (error: any) => void,
   readonly onScriptLoadFailure?: (error: any) => void,
   readonly onAutoLoadFinished?: (successLogin: boolean) => void,

--- a/index.d.ts
+++ b/index.d.ts
@@ -128,12 +128,12 @@ export class GoogleLogout extends Component<GoogleLogoutProps, unknown> {
   public signOut(): void;
 }
 
-export interface UseGoogleLogoutResponse { 
+export interface UseGoogleLogoutResponse {
   signOut: () => void;
   loaded: boolean;
 }
 
-export interface UseGoogleLogoutProps { 
+export interface UseGoogleLogoutProps {
   readonly clientId: string,
   readonly onLogoutSuccess?: () => void;
   readonly onFailure?: () => void;
@@ -151,14 +151,17 @@ export interface UseGoogleLogoutProps {
 
 export function useGoogleLogout(input: UseGoogleLogoutProps): UseGoogleLogoutResponse;
 
-export interface UseGoogleLoginResponse { 
+export interface UseGoogleLoginResponse {
   signIn: () => void;
+  addScopes: (scopes: string) => void;
   loaded: boolean;
 }
 
-export interface UseGoogleLoginProps { 
+export interface UseGoogleLoginProps {
   readonly onSuccess?: (response: GoogleLoginResponse | GoogleLoginResponseOffline) => void,
   readonly onFailure?: (error: any) => void,
+  readonly onAddScopesSuccess?: (response: GoogleLoginResponse) => void,
+  readonly onAddScopesFailure?: (error: any) => void,
   readonly onScriptLoadFailure?: (error: any) => void,
   readonly onAutoLoadFinished?: (successLogin: boolean) => void,
   readonly clientId: string,

--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -75,9 +75,13 @@ const useGoogleLogin = ({
 
   function addScopes(newScope) {
     if (loaded) {
+      const options = {
+        prompt,
+        access_type: accessType
+      }
       const auth = window.gapi.auth2.getAuthInstance()
       const user = auth.currentUser.get()
-      user.grant({ scope: newScope }).then(
+      user.grant({ ...options, scope: newScope }).then(
         res => handleSigninSuccess(res, onAddScopesSuccess),
         err => onAddScopesFailure(err)
       )

--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -28,7 +28,7 @@ const useGoogleLogin = ({
 }) => {
   const [loaded, setLoaded] = useState(false)
 
-  function handleSigninSuccess(res) {
+  function handleSigninSuccess(res, handleSuccess) {
     /*
       offer renamed response keys to names that match use
     */
@@ -46,7 +46,7 @@ const useGoogleLogin = ({
       givenName: basicProfile.getGivenName(),
       familyName: basicProfile.getFamilyName()
     }
-    onSuccess(res)
+    handleSuccess(res)
   }
 
   function signIn(e) {
@@ -66,7 +66,7 @@ const useGoogleLogin = ({
         )
       } else {
         GoogleAuth.signIn(options).then(
-          res => handleSigninSuccess(res),
+          res => handleSigninSuccess(res, onSuccess),
           err => onFailure(err)
         )
       }
@@ -78,7 +78,7 @@ const useGoogleLogin = ({
       const auth = window.gapi.auth2.getAuthInstance()
       const user = auth.currentUser.get()
       user.grant({ scope: newScope }).then(
-        res => onAddScopesSuccess(res),
+        res => handleSigninSuccess(res, onAddScopesSuccess),
         err => onAddScopesFailure(err)
       )
     }
@@ -120,7 +120,7 @@ const useGoogleLogin = ({
                   const signedIn = isSignedIn && res.isSignedIn.get()
                   onAutoLoadFinished(signedIn)
                   if (signedIn) {
-                    handleSigninSuccess(res.currentUser.get())
+                    handleSigninSuccess(res.currentUser.get(), onSuccess)
                   }
                 }
               },
@@ -139,7 +139,7 @@ const useGoogleLogin = ({
                 if (isSignedIn && GoogleAuth.isSignedIn.get()) {
                   setLoaded(true)
                   onAutoLoadFinished(true)
-                  handleSigninSuccess(GoogleAuth.currentUser.get())
+                  handleSigninSuccess(GoogleAuth.currentUser.get(), onSuccess)
                 } else {
                   setLoaded(true)
                   onAutoLoadFinished(false)

--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -76,15 +76,21 @@ const useGoogleLogin = ({
   function addScopes(newScope) {
     if (loaded) {
       const options = {
-        prompt,
-        access_type: accessType
+        prompt
       }
       const auth = window.gapi.auth2.getAuthInstance()
       const user = auth.currentUser.get()
-      user.grant({ ...options, scope: newScope }).then(
-        res => handleSigninSuccess(res, onAddScopesSuccess),
-        err => onAddScopesFailure(err)
-      )
+      if (responseType === 'code') {
+        auth.grantOfflineAccess({ ...options, scope: newScope }).then(
+          res => onAddScopesSuccess(res),
+          err => onAddScopesFailure(err)
+        )
+      } else {
+        user.grant({ ...options, scope: newScope }).then(
+          res => handleSigninSuccess(res, onAddScopesSuccess),
+          err => onAddScopesFailure(err)
+        )
+      }
     }
   }
 

--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -7,6 +7,8 @@ const useGoogleLogin = ({
   onAutoLoadFinished = () => {},
   onFailure = () => {},
   onRequest = () => {},
+  onAddScopesSuccess = () => {},
+  onAddScopesFailure = () => {},
   onScriptLoadFailure,
   clientId,
   cookiePolicy,
@@ -68,6 +70,17 @@ const useGoogleLogin = ({
           err => onFailure(err)
         )
       }
+    }
+  }
+
+  function addScopes(newScope) {
+    if (loaded) {
+      const auth = window.gapi.auth2.getAuthInstance()
+      const user = auth.currentUser.get()
+      user.grant({ scope: newScope }).then(
+        res => onAddScopesSuccess(res),
+        err => onAddScopesFailure(err)
+      )
     }
   }
 
@@ -156,7 +169,7 @@ const useGoogleLogin = ({
     }
   }, [loaded])
 
-  return { signIn, loaded }
+  return { signIn, addScopes, loaded }
 }
 
 export default useGoogleLogin


### PR DESCRIPTION
Google Sign-In allows requesting additional permissions as described in the [official documentation](ttps://developers.google.com/identity/sign-in/web/incremental-auth). In this PR, I follow the proposed approach in https://github.com/anthonyjgrove/react-google-login/issues/348:

The `useGoogleLogin` hook exposes the new `addScopes` method. This hook also supports two new callbacks, `onAddScopesSuccess` and `onAddScopesFailure`, to handle the method response:

```js
import { useGoogleLogin } from 'react-google-login'

const { addScopes } = useGoogleLogin({
  clientId,
  onAddScopesSuccess,
  onAddScopesSuccess
})
```

**NOTE:** Since there are two `accessType` to authorize scopes: online and offline. The `addScopes` method will use `user.grant(options)` or `auth.grantOfflineAccess(options)`. This method would be only executed if the user is logged in.

This PR is for https://github.com/anthonyjgrove/react-google-login/issues/348 and https://github.com/anthonyjgrove/react-google-login/issues/371. 
