### PR TITLE
types: Fix onSuccess callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,12 @@
 /* eslint-disable max-classes-per-file */
-// Type definitions for react-google-login v2.5.4
+// Type definitions for react-google-login v5.2
 // Project: https://github.com/anthonyjgrove/react-google-login
 // Definitions by: Ruslan Ibragimov <https://github.com/IRus>
 import {Component, ReactNode, CSSProperties} from 'react';
 
 export as namespace ReactGoogleLogin;
 
+// https://developers.google.com/identity/sign-in/web/reference#gapiauth2authresponse
 interface AuthResponse {
   readonly access_token: string;
   readonly id_token: string;
@@ -44,7 +45,6 @@ export interface GoogleLoginResponse {
   tokenObj: AuthResponse;
   tokenId: string;
   accessToken: string;
-  readonly code?: string;//does not exist but here to satisfy typescript compatibility
   profileObj: {
     googleId: string;
     imageUrl: string;
@@ -71,8 +71,8 @@ export interface GoogleLoginResponseOffline {
   readonly code: string;
 }
 
-export interface GoogleLoginProps {
-  readonly onSuccess?: (response: GoogleLoginResponse | GoogleLoginResponseOffline) => void,
+export interface GoogleLoginProps<T> {
+  readonly onSuccess?: T extends 'code' ? (response: GoogleLoginResponseOffline) => void : (response: GoogleLoginResponse) => void,
   readonly onAutoLoadFinished?: (successLogin: boolean) => void,
   readonly onFailure?: (error: any) => void,
   readonly onScriptLoadFailure?: (error: any) => void,
@@ -87,7 +87,7 @@ export interface GoogleLoginProps {
   readonly loginHint?: string,
   readonly hostedDomain?: string,
   readonly prompt?: string,
-  readonly responseType?: string,
+  readonly responseType?: 'code' | T,
   readonly children?: ReactNode,
   readonly style?: CSSProperties,
   readonly icon?: boolean,
@@ -104,7 +104,7 @@ export interface GoogleLoginProps {
   readonly render?: (props: { onClick: () => void, disabled?: boolean }) => JSX.Element;
 }
 
-export class GoogleLogin extends Component<GoogleLoginProps, unknown> {
+export class GoogleLogin<T extends string> extends Component<GoogleLoginProps<T>, unknown> {
   public signIn(e?: Event): void;
 }
 
@@ -156,8 +156,8 @@ export interface UseGoogleLoginResponse {
   loaded: boolean;
 }
 
-export interface UseGoogleLoginProps { 
-  readonly onSuccess?: (response: GoogleLoginResponse | GoogleLoginResponseOffline) => void,
+export interface UseGoogleLoginProps<T> { 
+  readonly onSuccess?: T extends 'code' ? (response: GoogleLoginResponseOffline) => void : (response: GoogleLoginResponse) => void,
   readonly onFailure?: (error: any) => void,
   readonly onScriptLoadFailure?: (error: any) => void,
   readonly onAutoLoadFinished?: (successLogin: boolean) => void,
@@ -170,7 +170,7 @@ export interface UseGoogleLoginProps {
   readonly loginHint?: string,
   readonly hostedDomain?: string,
   readonly prompt?: string,
-  readonly responseType?: string,
+  readonly responseType?: 'code' | T,
   readonly autoLoad?: boolean;
   readonly uxMode?: string;
   readonly fetchBasicProfile?: boolean;
@@ -179,6 +179,6 @@ export interface UseGoogleLoginProps {
   readonly accessType?: string;
 }
 
-export function useGoogleLogin(input: UseGoogleLoginProps): UseGoogleLoginResponse;
+export function useGoogleLogin<T extends string>(input: UseGoogleLoginProps<T>): UseGoogleLoginResponse;
 
 export default GoogleLogin;


### PR DESCRIPTION
Currently we have a `code` property on the `GoogleLoginResponse` interface that isn't actually there and is just a hack for people doing the offline flow. Additionally, if using the online flow in TypeScript you can't safely access any of the properties and need to cast the argument of the onSuccess callback to get them.

This PR fixes these issues by properly handling the `responseType` property that determines what the `onSuccess` callback's argument is.

This allows us to do this in TypeScript without errors (currently, this errors as TypeScript is not sure whether res is a GoogleLoginResponse or a GoogleLoginResponseOffline):

![image](https://user-images.githubusercontent.com/4953590/134776733-9c9b15ad-9e21-4004-8b29-93ddcb9e2ef6.png)

While still erroring about bad property accesses when the responseType is code:

![image](https://user-images.githubusercontent.com/4953590/134776755-92b031c8-5c8b-44ec-b948-6833c1c89e4e.png)

But of course still allowing us to get the code when responseType is code:

![image](https://user-images.githubusercontent.com/4953590/134776768-cfb53450-aca0-4298-8d62-a2bd7ccb8c70.png)