### PR TITLE
Plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ const { signIn, loaded } = useGoogleLogin({
     responseType,
     jsSrc,
     onRequest,
-    prompt
+    prompt,
+    pluginName
   })
 ```
 ## Logout Hook
@@ -168,6 +169,7 @@ Use GoogleLogout button to logout the user from google.
 | redirectUri       |  string  |  -   | If using ux_mode='redirect', this parameter allows you to override the default redirect_uri that will be used at the end of the consent flow. The default redirect_uri is the current URL stripped of query parameters and hash fragment. |
 | isSignedIn | boolean | false | If true will return GoogleUser object on load, if user has given your app permission |
 | render       | function | -                                     | Render prop to use a custom element, use renderProps.onClick |
+| pluginName   | string   | -                                     | Enables legacy use for new client IDs created before July 29th 2022, as described here (https://developers.google.com/identity/sign-in/web/reference) |
 Google Scopes List: [scopes](https://developers.google.com/identity/protocols/googlescopes)
 
 ## Logout Props

--- a/src/google-login.js
+++ b/src/google-login.js
@@ -37,7 +37,8 @@ const GoogleLogin = props => {
     accessType,
     responseType,
     jsSrc,
-    prompt
+    prompt,
+    pluginName
   } = props
 
   const { signIn, loaded } = useGoogleLogin({
@@ -60,7 +61,8 @@ const GoogleLogin = props => {
     accessType,
     responseType,
     jsSrc,
-    prompt
+    prompt,
+    pluginName
   })
   const disabled = disabledProp || !loaded
 
@@ -169,7 +171,8 @@ GoogleLogin.propTypes = {
   accessType: PropTypes.string,
   render: PropTypes.func,
   theme: PropTypes.string,
-  icon: PropTypes.bool
+  icon: PropTypes.bool,
+  pluginName: PropTypes.string
 }
 
 GoogleLogin.defaultProps = {

--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -22,7 +22,8 @@ const useGoogleLogin = ({
   accessType,
   responseType,
   jsSrc = 'https://apis.google.com/js/api.js',
-  prompt
+  prompt,
+  pluginName
 }) => {
   const [loaded, setLoaded] = useState(false)
 
@@ -90,7 +91,8 @@ const useGoogleLogin = ({
           ux_mode: uxMode,
           redirect_uri: redirectUri,
           scope,
-          access_type: accessType
+          access_type: accessType,
+          plugin_name: pluginName
         }
 
         if (responseType === 'code') {


### PR DESCRIPTION
This enables use of Google Sign-In until July 29th 2022 as described at the top of the page here: https://developers.google.com/identity/sign-in/web/reference.

Added a pluginName parameter to useGoogleLogin which gets passed to window.gapi.auth2.init.
Also added a pluginName prop to GoogleLogin which gets passed to useGoogleLogin.

My first pull request, I hope it's acceptable :)