### PR TITLE
Add 'plugin-name' in params for gapi.auth2.init

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,37 +137,38 @@ Use GoogleLogout button to logout the user from google.
   ```
 ## Login Props
 
-|    params    |   value  |             default value            |   description    |
-|:------------:|:--------:|:------------------------------------:|:----------------:|
-|    clientId  |  string  |               REQUIRED               | You can create a clientID by creating a [new project on Google developers website.](https://developers.google.com/identity/sign-in/web/sign-in) |
-|    jsSrc     |  string  |https://apis.google.com/js/api.js|URL of the Javascript file normally hosted by Google|
-| hostedDomain |  string  |                   -                  |The G Suite domain to which users must belong to sign in|
-|     scope    |  string  |             profile email            |                  |
-| responseType |  string  |              permission              | Can be either space-delimited 'id_token', to retrieve an ID Token + 'permission' (or 'token'), to retrieve an Access Token, or 'code', to retrieve an Authorization Code.
-| accessType   |  string  |              online                  | Can be either 'online' or 'offline'. Use offline with responseType 'code' to retrieve an authorization code for fetching a refresh token  |
-|   onSuccess  | function |               REQUIRED               |                  |
-|   onFailure  | function |               REQUIRED               |                  |
-|   onScriptLoadFailure  | function |         -                  | If defined, will be called when loading the 'google-login' script fails (otherwise onFailure will be called) |
-|   onRequest  | function |                   -                  |                  |
-|   onAutoLoadFinished  | function |                   -         |                  |
-|   buttonText |  string  |             Login with Google        |                  |
-|   className  |  string  |                   -                  |                  |
-|    style     |  object  |                   -                  |                  |
-| disabledStyle|  object  |                   -                  |                  |
-|   loginHint  |  string  |                   -                  |                  |
-|    prompt    |  string  |                   -                  | Can be 'consent' to force google return refresh token.                |
-|     tag      |  string  |                button                |  sets element tag (div, a, span, etc     |
-|     type      |  string  |               button                |sets button type (submit || button)     |
-|   autoLoad   |  boolean |                 false                |                  |
-| fetchBasicProfile | boolean | true                            |                  |
-| disabled | boolean | false                            |                  |
-| discoveryDocs | - | https://developers.google.com/discovery/v1/using |
-| uxMode       |  string  |  popup   | The UX mode to use for the sign-in flow. Valid values are popup and redirect. |
-| theme | string | light | If set to `dark` the button will follow the Google brand guidelines for dark. Otherwise it will default to light (https://developers.google.com/identity/branding-guidelines) |
-| icon | boolean | true | Show (`true`) or hide (`false`) the Google Icon |
-| redirectUri       |  string  |  -   | If using ux_mode='redirect', this parameter allows you to override the default redirect_uri that will be used at the end of the consent flow. The default redirect_uri is the current URL stripped of query parameters and hash fragment. |
-| isSignedIn | boolean | false | If true will return GoogleUser object on load, if user has given your app permission |
-| render       | function | -                                     | Render prop to use a custom element, use renderProps.onClick |
+|       params        |  value   |             default value            |   description    |
+|:-------------------:|:--------:|:------------------------------------:|:----------------:|
+|      clientId       |  string  |               REQUIRED               | You can create a clientID by creating a [new project on Google developers website.](https://developers.google.com/identity/sign-in/web/sign-in) |
+|        jsSrc        |  string  |https://apis.google.com/js/api.js|URL of the Javascript file normally hosted by Google|
+|    hostedDomain     |  string  |                   -                  |The G Suite domain to which users must belong to sign in|
+|        scope        |  string  |             profile email            |                  |
+|    responseType     |  string  |              permission              | Can be either space-delimited 'id_token', to retrieve an ID Token + 'permission' (or 'token'), to retrieve an Access Token, or 'code', to retrieve an Authorization Code.
+|     accessType      |  string  |              online                  | Can be either 'online' or 'offline'. Use offline with responseType 'code' to retrieve an authorization code for fetching a refresh token  |
+|      onSuccess      | function |               REQUIRED               |                  |
+|      onFailure      | function |               REQUIRED               |                  |
+| onScriptLoadFailure | function |         -                  | If defined, will be called when loading the 'google-login' script fails (otherwise onFailure will be called) |
+|      onRequest      | function |                   -                  |                  |
+| onAutoLoadFinished  | function |                   -         |                  |
+|     buttonText      |  string  |             Login with Google        |                  |
+|      className      |  string  |                   -                  |                  |
+|        style        |  object  |                   -                  |                  |
+|    disabledStyle    |  object  |                   -                  |                  |
+|      loginHint      |  string  |                   -                  |                  |
+|       prompt        |  string  |                   -                  | Can be 'consent' to force google return refresh token.                |
+|         tag         |  string  |                button                |  sets element tag (div, a, span, etc     |
+|        type         |  string  |               button                |sets button type (submit || button)     |
+|      autoLoad       | boolean  |                 false                |                  |
+|  fetchBasicProfile  | boolean  | true                            |                  |
+|      disabled       | boolean  | false                            |                  |
+|    discoveryDocs    |    -     | https://developers.google.com/discovery/v1/using |
+|       uxMode        |  string  |  popup   | The UX mode to use for the sign-in flow. Valid values are popup and redirect. |
+|        theme        |  string  | light | If set to `dark` the button will follow the Google brand guidelines for dark. Otherwise it will default to light (https://developers.google.com/identity/branding-guidelines) |
+|        icon         | boolean  | true | Show (`true`) or hide (`false`) the Google Icon |
+|     redirectUri     |  string  |  -   | If using ux_mode='redirect', this parameter allows you to override the default redirect_uri that will be used at the end of the consent flow. The default redirect_uri is the current URL stripped of query parameters and hash fragment. |
+|     isSignedIn      | boolean  | false | If true will return GoogleUser object on load, if user has given your app permission |
+|       render        | function | -                                     | Render prop to use a custom element, use renderProps.onClick |
+|     pluginName      |  string  | - | If this value is is set, new Client IDs created before July 29th, 2022 can use the older Google Platform Library. By default, newly created Client IDs are now blocked from using the Platform Library and instead must use the newer Google Identity Services library. You may choose any value, a descriptive name such as product or plugin name is recommended for easy identification. Example: plugin_name: 'YOUR_STRING_HERE' |
 Google Scopes List: [scopes](https://developers.google.com/identity/protocols/googlescopes)
 
 ## Logout Props

--- a/src/google-login.js
+++ b/src/google-login.js
@@ -169,7 +169,8 @@ GoogleLogin.propTypes = {
   accessType: PropTypes.string,
   render: PropTypes.func,
   theme: PropTypes.string,
-  icon: PropTypes.bool
+  icon: PropTypes.bool,
+  pluginName: PropTypes.string
 }
 
 GoogleLogin.defaultProps = {

--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -22,7 +22,8 @@ const useGoogleLogin = ({
   accessType,
   responseType,
   jsSrc = 'https://apis.google.com/js/api.js',
-  prompt
+  prompt,
+  pluginName
 }) => {
   const [loaded, setLoaded] = useState(false)
 
@@ -90,7 +91,8 @@ const useGoogleLogin = ({
           ux_mode: uxMode,
           redirect_uri: redirectUri,
           scope,
-          access_type: accessType
+          access_type: accessType,
+          plugin_name: pluginName
         }
 
         if (responseType === 'code') {


### PR DESCRIPTION
From google developers https://developers.google.com/identity/sign-in/web/reference:
We are [discontinuing the Google Sign-In JavaScript Platform Library for web](https://developers.googleblog.com/2021/08/gsi-jsweb-deprecation.html). The library will be unavailable for download after the March 31, 2023 deprecation date. Instead, use the new Google Identity Services for [Web](https://developers.google.com/identity/gsi/web).
By default, newly created Client IDs are now blocked from using the older Platform Library, existing Client IDs are unaffected. New Client IDs created before July 29th, 2022 can set [`plugin_name`](https://developers.google.com/identity/sign-in/web/reference) to enable use of the Google Platform Library.